### PR TITLE
Feature/translations replacements

### DIFF
--- a/lang/events.pot
+++ b/lang/events.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-06 08:15+0100\n"
+"POT-Creation-Date: 2023-12-09 11:57+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,47 +18,51 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../lib/GaletteEvents/Booking.php:208
+#: ../lib/GaletteEvents/Booking.php:207
 msgid "Event is mandatory"
 msgstr ""
 
-#: ../lib/GaletteEvents/Booking.php:221
+#. TRANS: %1$s is activity name
+#: ../lib/GaletteEvents/Booking.php:219
+#, php-format
 msgid "%1$s is mandatory for this event!"
 msgstr ""
 
-#: ../lib/GaletteEvents/Booking.php:255
+#: ../lib/GaletteEvents/Booking.php:254
 msgid "Please specify amount if booking has been paid ;)"
 msgstr ""
 
-#: ../lib/GaletteEvents/Booking.php:278
+#: ../lib/GaletteEvents/Booking.php:277
 msgid "Member is mandatory"
 msgstr ""
 
-#: ../lib/GaletteEvents/Booking.php:290
+#: ../lib/GaletteEvents/Booking.php:289
 msgid "There must be at least one person"
 msgstr ""
 
-#: ../lib/GaletteEvents/Booking.php:299
+#: ../lib/GaletteEvents/Booking.php:298
 msgid "Booking date is mandatory!"
 msgstr ""
 
-#: ../lib/GaletteEvents/Booking.php:326
+#: ../lib/GaletteEvents/Booking.php:322
 msgid "booking date"
 msgstr ""
 
-#: ../lib/GaletteEvents/Booking.php:357
+#. TRANS: first replacement is member name, second is event name
+#: ../lib/GaletteEvents/Booking.php:344
+#, php-format
 msgid "A booking already exists for %1$s in %2$s"
 msgstr ""
 
-#: ../lib/GaletteEvents/Booking.php:424
+#: ../lib/GaletteEvents/Booking.php:413
 msgid "Booking added"
 msgstr ""
 
-#: ../lib/GaletteEvents/Booking.php:428
+#: ../lib/GaletteEvents/Booking.php:417
 msgid "Fail to add new booking."
 msgstr ""
 
-#: ../lib/GaletteEvents/Booking.php:446
+#: ../lib/GaletteEvents/Booking.php:435
 msgid "Booking updated"
 msgstr ""
 
@@ -94,7 +98,7 @@ msgstr ""
 msgid "Do not forget to store the booking"
 msgstr ""
 
-#. TRANS: first parameter is the member name, second the event name.
+#. TRANS: %1$s is the member name, %2$s the event name.
 #: ../lib/GaletteEvents/Controllers/Crud/BookingsController.php:648
 #, php-format
 msgid "Remove booking for %1$s on %2$s"
@@ -117,10 +121,11 @@ msgid "Activity has been modified."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:263
-msgid "An error occured while storing the activity."
+msgid "An error occurred while storing the activity."
 msgstr ""
 
-#: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:355
+#. TRANS %1$s is activity name
+#: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:348
 #, php-format
 msgid "Remove activity %1$s"
 msgstr ""
@@ -166,10 +171,10 @@ msgid "Event has been modified."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/EventsController.php:414
-msgid "An error occured while storing the event."
+msgid "An error occurred while storing the event."
 msgstr ""
 
-#. TRANS: first parameter is the event name
+#. TRANS: %1$s is the event name
 #: ../lib/GaletteEvents/Controllers/Crud/EventsController.php:514
 #, php-format
 msgid "Remove event '%1$s'\""
@@ -225,16 +230,17 @@ msgstr ""
 msgid "Comment:"
 msgstr ""
 
-#: ../lib/GaletteEvents/Repository/Events.php:236
+#. TRANS: %1$s is the number of paid attendees
+#: ../lib/GaletteEvents/Repository/Events.php:237
 #, php-format
 msgid "%1$s paid"
 msgstr ""
 
-#: ../lib/GaletteEvents/Repository/Events.php:241
+#: ../lib/GaletteEvents/Repository/Events.php:242
 msgid "Attendees:"
 msgstr ""
 
-#: ../lib/GaletteEvents/Repository/Events.php:249
+#: ../lib/GaletteEvents/Repository/Events.php:250
 #: ../lib/GaletteEvents/PluginGaletteEvents.php:113
 #: ../tempcache/event.html.twig:166 ../tempcache/booking.html.twig:213
 msgid "Activities"
@@ -252,31 +258,31 @@ msgstr ""
 msgid "End date"
 msgstr ""
 
-#: ../lib/GaletteEvents/Event.php:266
+#: ../lib/GaletteEvents/Event.php:261
 msgid "End date must be later or equal to begin date"
 msgstr ""
 
-#: ../lib/GaletteEvents/Event.php:272 ../lib/GaletteEvents/Activity.php:194
+#: ../lib/GaletteEvents/Event.php:267 ../lib/GaletteEvents/Activity.php:193
 msgid "Name is mandatory"
 msgstr ""
 
-#: ../lib/GaletteEvents/Event.php:289
+#: ../lib/GaletteEvents/Event.php:284
 msgid "Please select a group you own!"
 msgstr ""
 
-#: ../lib/GaletteEvents/Event.php:296
+#: ../lib/GaletteEvents/Event.php:291
 msgid "Town is mandatory"
 msgstr ""
 
-#: ../lib/GaletteEvents/Event.php:426
+#: ../lib/GaletteEvents/Event.php:421
 msgid "Event added"
 msgstr ""
 
-#: ../lib/GaletteEvents/Event.php:430
+#: ../lib/GaletteEvents/Event.php:425
 msgid "Fail to add new event."
 msgstr ""
 
-#: ../lib/GaletteEvents/Event.php:448
+#: ../lib/GaletteEvents/Event.php:443
 msgid "Event updated"
 msgstr ""
 
@@ -299,20 +305,20 @@ msgstr ""
 msgid "New event booking"
 msgstr ""
 
-#: ../lib/GaletteEvents/Activity.php:263
+#: ../lib/GaletteEvents/Activity.php:262
 msgid "Activity added"
 msgstr ""
 
-#: ../lib/GaletteEvents/Activity.php:268
+#: ../lib/GaletteEvents/Activity.php:267
 msgid "Fail to add new activity."
 msgstr ""
 
-#: ../lib/GaletteEvents/Activity.php:286
+#: ../lib/GaletteEvents/Activity.php:285
 msgid "Activity updated"
 msgstr ""
 
 #: ../tempcache/event.html.twig:63 ../tempcache/activity.html.twig:63
-msgid "General informations"
+msgid "General information"
 msgstr ""
 
 #: ../tempcache/event.html.twig:70
@@ -387,7 +393,7 @@ msgid "Please choose an activity to remove"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:63
-msgid "Booking informations"
+msgid "Booking information"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:70 ../tempcache/bookings.html.twig:138
@@ -404,7 +410,7 @@ msgid "No activity for selected event"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:280
-msgid "Financial informations"
+msgid "Financial information"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:287 ../tempcache/bookings.html.twig:138
@@ -525,11 +531,13 @@ msgstr ""
 msgid "Inactive"
 msgstr ""
 
-#: ../tempcache/activities.html.twig:203
-msgid "%1$s: edit informations"
+#: ../tempcache/activities.html.twig:203 ../tempcache/events.html.twig:253
+#, php-format
+msgid "%1$s: edit information"
 msgstr ""
 
-#: ../tempcache/activities.html.twig:205
+#: ../tempcache/activities.html.twig:205 ../tempcache/events.html.twig:266
+#, php-format
 msgid "%1$s: remove from database"
 msgstr ""
 
@@ -572,16 +580,6 @@ msgstr ""
 #: ../tempcache/events.html.twig:243
 #, php-format
 msgid "%1$s: show bookings"
-msgstr ""
-
-#: ../tempcache/events.html.twig:253
-#, php-format
-msgid "%1$s: edit informations"
-msgstr ""
-
-#: ../tempcache/events.html.twig:266
-#, php-format
-msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/events.html.twig:311

--- a/lang/events.pot
+++ b/lang/events.pot
@@ -23,7 +23,7 @@ msgid "Event is mandatory"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:221
-msgid "%activity is mandatory for this event!"
+msgid "%1$s is mandatory for this event!"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:255
@@ -47,7 +47,7 @@ msgid "booking date"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:357
-msgid "A booking already exists for %member in %event"
+msgid "A booking already exists for %1$s in %2$s"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:424
@@ -441,8 +441,8 @@ msgstr ""
 
 #: ../tempcache/bookings.html.twig:90
 #, php-format
-msgid "%count booking"
-msgid_plural "%count bookings"
+msgid "%1$s booking"
+msgid_plural "%1$s bookings"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -499,8 +499,8 @@ msgstr ""
 
 #: ../tempcache/activities.html.twig:61
 #, php-format
-msgid "%count activity"
-msgid_plural "%count activities"
+msgid "%1$s activity"
+msgid_plural "%1$s activities"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -526,11 +526,11 @@ msgid "Inactive"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:203
-msgid "%activity: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
-msgid "%activity: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:241
@@ -539,8 +539,8 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:61
 #, php-format
-msgid "%count event"
-msgid_plural "%count events"
+msgid "%1$s event"
+msgid_plural "%1$s events"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -566,22 +566,22 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:233
 #, php-format
-msgid "%eventname: export bookings as CSV"
+msgid "%1$s: export bookings as CSV"
 msgstr ""
 
 #: ../tempcache/events.html.twig:243
 #, php-format
-msgid "%eventname: show bookings"
+msgid "%1$s: show bookings"
 msgstr ""
 
 #: ../tempcache/events.html.twig:253
 #, php-format
-msgid "%eventname: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266
 #, php-format
-msgid "%eventname: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/events.html.twig:311

--- a/lang/events_ar.utf8.po
+++ b/lang/events_ar.utf8.po
@@ -116,7 +116,7 @@ msgid "Activity has been modified."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:263
-msgid "An error occured while storing the activity."
+msgid "An error occurred while storing the activity."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:355
@@ -165,7 +165,7 @@ msgid "Event has been modified."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/EventsController.php:414
-msgid "An error occured while storing the event."
+msgid "An error occurred while storing the event."
 msgstr ""
 
 #. TRANS: first parameter is the event name

--- a/lang/events_ar.utf8.po
+++ b/lang/events_ar.utf8.po
@@ -311,7 +311,7 @@ msgid "Activity updated"
 msgstr ""
 
 #: ../tempcache/event.html.twig:63 ../tempcache/activity.html.twig:63
-msgid "General informations"
+msgid "General information"
 msgstr ""
 
 #: ../tempcache/event.html.twig:70
@@ -386,7 +386,7 @@ msgid "Please choose an activity to remove"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:63
-msgid "Booking informations"
+msgid "Booking information"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:70 ../tempcache/bookings.html.twig:138
@@ -403,7 +403,7 @@ msgid "No activity for selected event"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:280
-msgid "Financial informations"
+msgid "Financial information"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:287 ../tempcache/bookings.html.twig:138
@@ -533,7 +533,7 @@ msgid "Inactive"
 msgstr "غير نَشِط"
 
 #: ../tempcache/activities.html.twig:203
-msgid "%1$s: edit informations"
+msgid "%1$s: edit information"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
@@ -583,11 +583,6 @@ msgstr ""
 #: ../tempcache/events.html.twig:243
 #, php-format
 msgid "%1$s: show bookings"
-msgstr ""
-
-#: ../tempcache/events.html.twig:253
-#, php-format
-msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266

--- a/lang/events_ar.utf8.po
+++ b/lang/events_ar.utf8.po
@@ -22,7 +22,7 @@ msgid "Event is mandatory"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:221
-msgid "%activity is mandatory for this event!"
+msgid "%1$s is mandatory for this event!"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:255
@@ -46,7 +46,7 @@ msgid "booking date"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:357
-msgid "A booking already exists for %member in %event"
+msgid "A booking already exists for %1$s in %2$s"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:424
@@ -440,8 +440,8 @@ msgstr ""
 
 #: ../tempcache/bookings.html.twig:90
 #, php-format
-msgid "%count booking"
-msgid_plural "%count bookings"
+msgid "%1$s booking"
+msgid_plural "%1$s bookings"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
@@ -502,8 +502,8 @@ msgstr ""
 
 #: ../tempcache/activities.html.twig:61
 #, php-format
-msgid "%count activity"
-msgid_plural "%count activities"
+msgid "%1$s activity"
+msgid_plural "%1$s activities"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
@@ -533,11 +533,11 @@ msgid "Inactive"
 msgstr "غير نَشِط"
 
 #: ../tempcache/activities.html.twig:203
-msgid "%activity: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
-msgid "%activity: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:241
@@ -546,8 +546,8 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:61
 #, php-format
-msgid "%count event"
-msgid_plural "%count events"
+msgid "%1$s event"
+msgid_plural "%1$s events"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
@@ -577,22 +577,22 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:233
 #, php-format
-msgid "%eventname: export bookings as CSV"
+msgid "%1$s: export bookings as CSV"
 msgstr ""
 
 #: ../tempcache/events.html.twig:243
 #, php-format
-msgid "%eventname: show bookings"
+msgid "%1$s: show bookings"
 msgstr ""
 
 #: ../tempcache/events.html.twig:253
 #, php-format
-msgid "%eventname: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266
 #, php-format
-msgid "%eventname: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/events.html.twig:311

--- a/lang/events_br.utf8.po
+++ b/lang/events_br.utf8.po
@@ -17,7 +17,7 @@ msgid "Event is mandatory"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:221
-msgid "%activity is mandatory for this event!"
+msgid "%1$s is mandatory for this event!"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:255
@@ -41,7 +41,7 @@ msgid "booking date"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:357
-msgid "A booking already exists for %member in %event"
+msgid "A booking already exists for %1$s in %$2s"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:424
@@ -435,8 +435,8 @@ msgstr ""
 
 #: ../tempcache/bookings.html.twig:90
 #, php-format
-msgid "%count booking"
-msgid_plural "%count bookings"
+msgid "%1$s booking"
+msgid_plural "%1$s bookings"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -493,8 +493,8 @@ msgstr ""
 
 #: ../tempcache/activities.html.twig:61
 #, php-format
-msgid "%count activity"
-msgid_plural "%count activities"
+msgid "%1$s activity"
+msgid_plural "%1$s activities"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -520,11 +520,11 @@ msgid "Inactive"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:203
-msgid "%activity: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
-msgid "%activity: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:241
@@ -533,8 +533,8 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:61
 #, php-format
-msgid "%count event"
-msgid_plural "%count events"
+msgid "%1$s event"
+msgid_plural "%1$s events"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -560,22 +560,22 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:233
 #, php-format
-msgid "%eventname: export bookings as CSV"
+msgid "%1$s: export bookings as CSV"
 msgstr ""
 
 #: ../tempcache/events.html.twig:243
 #, php-format
-msgid "%eventname: show bookings"
+msgid "%1$s: show bookings"
 msgstr ""
 
 #: ../tempcache/events.html.twig:253
 #, php-format
-msgid "%eventname: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266
 #, php-format
-msgid "%eventname: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/events.html.twig:311

--- a/lang/events_br.utf8.po
+++ b/lang/events_br.utf8.po
@@ -306,7 +306,7 @@ msgid "Activity updated"
 msgstr ""
 
 #: ../tempcache/event.html.twig:63 ../tempcache/activity.html.twig:63
-msgid "General informations"
+msgid "General information"
 msgstr ""
 
 #: ../tempcache/event.html.twig:70
@@ -381,7 +381,7 @@ msgid "Please choose an activity to remove"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:63
-msgid "Booking informations"
+msgid "Booking information"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:70 ../tempcache/bookings.html.twig:138
@@ -398,7 +398,7 @@ msgid "No activity for selected event"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:280
-msgid "Financial informations"
+msgid "Financial information"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:287 ../tempcache/bookings.html.twig:138
@@ -520,7 +520,7 @@ msgid "Inactive"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:203
-msgid "%1$s: edit informations"
+msgid "%1$s: edit information"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
@@ -566,11 +566,6 @@ msgstr ""
 #: ../tempcache/events.html.twig:243
 #, php-format
 msgid "%1$s: show bookings"
-msgstr ""
-
-#: ../tempcache/events.html.twig:253
-#, php-format
-msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266

--- a/lang/events_br.utf8.po
+++ b/lang/events_br.utf8.po
@@ -111,7 +111,7 @@ msgid "Activity has been modified."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:263
-msgid "An error occured while storing the activity."
+msgid "An error occurred while storing the activity."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:355
@@ -160,7 +160,7 @@ msgid "Event has been modified."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/EventsController.php:414
-msgid "An error occured while storing the event."
+msgid "An error occurred while storing the event."
 msgstr ""
 
 #. TRANS: first parameter is the event name

--- a/lang/events_ca.utf8.po
+++ b/lang/events_ca.utf8.po
@@ -115,7 +115,7 @@ msgid "Activity has been modified."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:263
-msgid "An error occured while storing the activity."
+msgid "An error occurred while storing the activity."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:355
@@ -164,7 +164,7 @@ msgid "Event has been modified."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/EventsController.php:414
-msgid "An error occured while storing the event."
+msgid "An error occurred while storing the event."
 msgstr ""
 
 #. TRANS: first parameter is the event name

--- a/lang/events_ca.utf8.po
+++ b/lang/events_ca.utf8.po
@@ -21,7 +21,7 @@ msgid "Event is mandatory"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:221
-msgid "%activity is mandatory for this event!"
+msgid "%1$s is mandatory for this event!"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:255
@@ -45,7 +45,7 @@ msgid "booking date"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:357
-msgid "A booking already exists for %member in %event"
+msgid "A booking already exists for %1$s in %2$s"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:424
@@ -439,8 +439,8 @@ msgstr ""
 
 #: ../tempcache/bookings.html.twig:90
 #, php-format
-msgid "%count booking"
-msgid_plural "%count bookings"
+msgid "%1$s booking"
+msgid_plural "%1$s bookings"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -497,8 +497,8 @@ msgstr ""
 
 #: ../tempcache/activities.html.twig:61
 #, php-format
-msgid "%count activity"
-msgid_plural "%count activities"
+msgid "%1$s activity"
+msgid_plural "%1$s activities"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -524,11 +524,11 @@ msgid "Inactive"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:203
-msgid "%activity: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
-msgid "%activity: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:241
@@ -537,8 +537,8 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:61
 #, php-format
-msgid "%count event"
-msgid_plural "%count events"
+msgid "%1$s event"
+msgid_plural "%1$s events"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -564,22 +564,22 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:233
 #, php-format
-msgid "%eventname: export bookings as CSV"
+msgid "%1$s: export bookings as CSV"
 msgstr ""
 
 #: ../tempcache/events.html.twig:243
 #, php-format
-msgid "%eventname: show bookings"
+msgid "%1$s: show bookings"
 msgstr ""
 
 #: ../tempcache/events.html.twig:253
 #, php-format
-msgid "%eventname: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266
 #, php-format
-msgid "%eventname: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/events.html.twig:311

--- a/lang/events_ca.utf8.po
+++ b/lang/events_ca.utf8.po
@@ -310,7 +310,7 @@ msgid "Activity updated"
 msgstr ""
 
 #: ../tempcache/event.html.twig:63 ../tempcache/activity.html.twig:63
-msgid "General informations"
+msgid "General information"
 msgstr ""
 
 #: ../tempcache/event.html.twig:70
@@ -385,7 +385,7 @@ msgid "Please choose an activity to remove"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:63
-msgid "Booking informations"
+msgid "Booking information"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:70 ../tempcache/bookings.html.twig:138
@@ -402,7 +402,7 @@ msgid "No activity for selected event"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:280
-msgid "Financial informations"
+msgid "Financial information"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:287 ../tempcache/bookings.html.twig:138
@@ -524,7 +524,7 @@ msgid "Inactive"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:203
-msgid "%1$s: edit informations"
+msgid "%1$s: edit information"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
@@ -570,11 +570,6 @@ msgstr ""
 #: ../tempcache/events.html.twig:243
 #, php-format
 msgid "%1$s: show bookings"
-msgstr ""
-
-#: ../tempcache/events.html.twig:253
-#, php-format
-msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266

--- a/lang/events_de_DE.utf8.po
+++ b/lang/events_de_DE.utf8.po
@@ -26,8 +26,8 @@ msgid "Event is mandatory"
 msgstr "Ereignis ist erforderlich"
 
 #: ../lib/GaletteEvents/Booking.php:221
-msgid "%activity is mandatory for this event!"
-msgstr "%activity ist erforderlich für dieses Ereignis!"
+msgid "%1$s is mandatory for this event!"
+msgstr "%1$s ist erforderlich für dieses Ereignis!"
 
 #: ../lib/GaletteEvents/Booking.php:255
 msgid "Please specify amount if booking has been paid ;)"
@@ -52,8 +52,8 @@ msgid "booking date"
 msgstr "Buchungsdatum"
 
 #: ../lib/GaletteEvents/Booking.php:357
-msgid "A booking already exists for %member in %event"
-msgstr "Es gibt bereits eine Buchung für %member in %event"
+msgid "A booking already exists for %1$s in %2$s"
+msgstr "Es gibt bereits eine Buchung für %1$s in %2$s"
 
 #: ../lib/GaletteEvents/Booking.php:424
 msgid "Booking added"
@@ -457,8 +457,8 @@ msgstr ""
 
 #: ../tempcache/bookings.html.twig:90
 #, php-format
-msgid "%count booking"
-msgid_plural "%count bookings"
+msgid "%1$s booking"
+msgid_plural "%1$s bookings"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -515,10 +515,10 @@ msgstr ""
 
 #: ../tempcache/activities.html.twig:61
 #, php-format
-msgid "%count activity"
-msgid_plural "%count activities"
-msgstr[0] "%count Aktivität"
-msgstr[1] "%count Aktivitäten"
+msgid "%1$s activity"
+msgid_plural "%1$s activities"
+msgstr[0] "%1$s Aktivität"
+msgstr[1] "%1$s Aktivitäten"
 
 #: ../tempcache/activities.html.twig:88
 #, fuzzy
@@ -543,11 +543,11 @@ msgid "Inactive"
 msgstr "Inaktiv"
 
 #: ../tempcache/activities.html.twig:203
-msgid "%activity: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
-msgid "%activity: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:241
@@ -556,8 +556,8 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:61
 #, php-format
-msgid "%count event"
-msgid_plural "%count events"
+msgid "%1$s event"
+msgid_plural "%1$s events"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -583,22 +583,22 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:233
 #, php-format
-msgid "%eventname: export bookings as CSV"
+msgid "%1$s: export bookings as CSV"
 msgstr ""
 
 #: ../tempcache/events.html.twig:243
 #, php-format
-msgid "%eventname: show bookings"
+msgid "%1$s: show bookings"
 msgstr ""
 
 #: ../tempcache/events.html.twig:253
 #, php-format
-msgid "%eventname: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266
 #, php-format
-msgid "%eventname: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/events.html.twig:311

--- a/lang/events_de_DE.utf8.po
+++ b/lang/events_de_DE.utf8.po
@@ -124,7 +124,7 @@ msgid "Activity has been modified."
 msgstr "Aktivität wurde verändert."
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:263
-msgid "An error occured while storing the activity."
+msgid "An error occurred while storing the activity."
 msgstr "Ein Fehler ist beim Speichern der Aktivität aufgetreten."
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:355
@@ -174,7 +174,7 @@ msgid "Event has been modified."
 msgstr "Event wurde verändert."
 
 #: ../lib/GaletteEvents/Controllers/Crud/EventsController.php:414
-msgid "An error occured while storing the event."
+msgid "An error occurred while storing the event."
 msgstr "Ein Fehler ist beim Speichern des Events aufgetreten."
 
 #. TRANS: first parameter is the event name

--- a/lang/events_de_DE.utf8.po
+++ b/lang/events_de_DE.utf8.po
@@ -320,7 +320,7 @@ msgid "Activity updated"
 msgstr "Aktivität aktualisiert"
 
 #: ../tempcache/event.html.twig:63 ../tempcache/activity.html.twig:63
-msgid "General informations"
+msgid "General information"
 msgstr "Allgemeine Informationen"
 
 #: ../tempcache/event.html.twig:70
@@ -401,7 +401,7 @@ msgid "Please choose an activity to remove"
 msgstr "Auswählen einer Aktivität um sie zu entfernen"
 
 #: ../tempcache/booking.html.twig:63
-msgid "Booking informations"
+msgid "Booking information"
 msgstr "Buchungsinformationen"
 
 #: ../tempcache/booking.html.twig:70 ../tempcache/bookings.html.twig:138
@@ -418,7 +418,7 @@ msgid "No activity for selected event"
 msgstr "Keine Aktivität für das ausgewählte Event"
 
 #: ../tempcache/booking.html.twig:280
-msgid "Financial informations"
+msgid "Financial information"
 msgstr "Zahlungsinformationen"
 
 #: ../tempcache/booking.html.twig:287 ../tempcache/bookings.html.twig:138
@@ -543,7 +543,7 @@ msgid "Inactive"
 msgstr "Inaktiv"
 
 #: ../tempcache/activities.html.twig:203
-msgid "%1$s: edit informations"
+msgid "%1$s: edit information"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
@@ -589,11 +589,6 @@ msgstr ""
 #: ../tempcache/events.html.twig:243
 #, php-format
 msgid "%1$s: show bookings"
-msgstr ""
-
-#: ../tempcache/events.html.twig:253
-#, php-format
-msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266

--- a/lang/events_en_US.po
+++ b/lang/events_en_US.po
@@ -22,8 +22,8 @@ msgid "Event is mandatory"
 msgstr "Event is mandatory"
 
 #: ../lib/GaletteEvents/Booking.php:221
-msgid "%activity is mandatory for this event!"
-msgstr "%activity is mandatory for this event!"
+msgid "%1$s is mandatory for this event!"
+msgstr "%1$s is mandatory for this event!"
 
 #: ../lib/GaletteEvents/Booking.php:255
 msgid "Please specify amount if booking has been paid ;)"
@@ -46,8 +46,8 @@ msgid "booking date"
 msgstr "booking date"
 
 #: ../lib/GaletteEvents/Booking.php:357
-msgid "A booking already exists for %member in %event"
-msgstr "A booking already exists for %member in %event"
+msgid "A booking already exists for %1$s in %2$s"
+msgstr "A booking already exists for %1$s in %2$s"
 
 #: ../lib/GaletteEvents/Booking.php:424
 msgid "Booking added"
@@ -442,10 +442,10 @@ msgstr "Export selected reservations as CSV"
 
 #: ../tempcache/bookings.html.twig:90
 #, php-format
-msgid "%count booking"
-msgid_plural "%count bookings"
-msgstr[0] "%count booking"
-msgstr[1] "%count bookings"
+msgid "%1$s booking"
+msgid_plural "%1$s bookings"
+msgstr[0] "%1$s booking"
+msgstr[1] "%1$s bookings"
 
 #: ../tempcache/bookings.html.twig:118 ../tempcache/calendar.html.twig:119
 msgid "New booking"
@@ -500,10 +500,10 @@ msgstr "No booking has been found"
 
 #: ../tempcache/activities.html.twig:61
 #, php-format
-msgid "%count activity"
-msgid_plural "%count activities"
-msgstr[0] "%count activity"
-msgstr[1] "%count activities"
+msgid "%1$s activity"
+msgid_plural "%1$s activities"
+msgstr[0] "%1$s activity"
+msgstr[1] "%1$s activities"
 
 #: ../tempcache/activities.html.twig:88
 msgid "New activity"
@@ -527,12 +527,12 @@ msgid "Inactive"
 msgstr "Inactive"
 
 #: ../tempcache/activities.html.twig:203
-msgid "%activity: edit informations"
-msgstr "%activity: edit informations"
+msgid "%1$s: edit informations"
+msgstr "%1$s: edit informations"
 
 #: ../tempcache/activities.html.twig:205
-msgid "%activity: remove from database"
-msgstr "%activity: remove from database"
+msgid "%1$s: remove from database"
+msgstr "%1$s: remove from database"
 
 #: ../tempcache/activities.html.twig:241
 msgid "No activity has been found"
@@ -540,10 +540,10 @@ msgstr "No activity has been found"
 
 #: ../tempcache/events.html.twig:61
 #, php-format
-msgid "%count event"
-msgid_plural "%count events"
-msgstr[0] "%count event"
-msgstr[1] "%count events"
+msgid "%1$s event"
+msgid_plural "%1$s events"
+msgstr[0] "%1$s event"
+msgstr[1] "%1$s events"
 
 #: ../tempcache/events.html.twig:88
 msgid "New event"
@@ -567,23 +567,23 @@ msgstr "Event is closed"
 
 #: ../tempcache/events.html.twig:233
 #, php-format
-msgid "%eventname: export bookings as CSV"
-msgstr "%eventname: export bookings as CSV"
+msgid "%1$s: export bookings as CSV"
+msgstr "%1$s: export bookings as CSV"
 
 #: ../tempcache/events.html.twig:243
 #, php-format
-msgid "%eventname: show bookings"
-msgstr "%eventname: show bookings"
+msgid "%1$s: show bookings"
+msgstr "%1$s: show bookings"
 
 #: ../tempcache/events.html.twig:253
 #, php-format
-msgid "%eventname: edit informations"
-msgstr "%eventname: edit informations"
+msgid "%1$s: edit informations"
+msgstr "%1$s: edit informations"
 
 #: ../tempcache/events.html.twig:266
 #, php-format
-msgid "%eventname: remove from database"
-msgstr "%eventname: remove from database"
+msgid "%1$s: remove from database"
+msgstr "%1$s: remove from database"
 
 #: ../tempcache/events.html.twig:311
 msgid "No event has been found"

--- a/lang/events_en_US.po
+++ b/lang/events_en_US.po
@@ -116,8 +116,8 @@ msgid "Activity has been modified."
 msgstr "Activity has been modified."
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:263
-msgid "An error occured while storing the activity."
-msgstr "An error occured while storing the activity."
+msgid "An error occurred while storing the activity."
+msgstr "An error occurred while storing the activity."
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:355
 #, php-format
@@ -165,8 +165,8 @@ msgid "Event has been modified."
 msgstr "Event has been modified."
 
 #: ../lib/GaletteEvents/Controllers/Crud/EventsController.php:414
-msgid "An error occured while storing the event."
-msgstr "An error occured while storing the event."
+msgid "An error occurred while storing the event."
+msgstr "An error occurred while storing the event."
 
 #. TRANS: first parameter is the event name
 #: ../lib/GaletteEvents/Controllers/Crud/EventsController.php:514

--- a/lang/events_en_US.po
+++ b/lang/events_en_US.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-06 08:15+0100\n"
-"PO-Revision-Date: 2023-12-06 08:15+0100\n"
+"POT-Creation-Date: 2023-12-09 11:57+0100\n"
+"PO-Revision-Date: 2023-12-09 11:57+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en_US\n"
@@ -17,47 +17,51 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../lib/GaletteEvents/Booking.php:208
+#: ../lib/GaletteEvents/Booking.php:207
 msgid "Event is mandatory"
 msgstr "Event is mandatory"
 
-#: ../lib/GaletteEvents/Booking.php:221
+#. TRANS: %1$s is activity name
+#: ../lib/GaletteEvents/Booking.php:219
+#, php-format
 msgid "%1$s is mandatory for this event!"
 msgstr "%1$s is mandatory for this event!"
 
-#: ../lib/GaletteEvents/Booking.php:255
+#: ../lib/GaletteEvents/Booking.php:254
 msgid "Please specify amount if booking has been paid ;)"
 msgstr "Please specify amount if booking has been paid ;)"
 
-#: ../lib/GaletteEvents/Booking.php:278
+#: ../lib/GaletteEvents/Booking.php:277
 msgid "Member is mandatory"
 msgstr "Member is mandatory"
 
-#: ../lib/GaletteEvents/Booking.php:290
+#: ../lib/GaletteEvents/Booking.php:289
 msgid "There must be at least one person"
 msgstr "There must be at least one person"
 
-#: ../lib/GaletteEvents/Booking.php:299
+#: ../lib/GaletteEvents/Booking.php:298
 msgid "Booking date is mandatory!"
 msgstr "Booking date is mandatory!"
 
-#: ../lib/GaletteEvents/Booking.php:326
+#: ../lib/GaletteEvents/Booking.php:322
 msgid "booking date"
 msgstr "booking date"
 
-#: ../lib/GaletteEvents/Booking.php:357
+#. TRANS: first replacement is member name, second is event name
+#: ../lib/GaletteEvents/Booking.php:344
+#, php-format
 msgid "A booking already exists for %1$s in %2$s"
 msgstr "A booking already exists for %1$s in %2$s"
 
-#: ../lib/GaletteEvents/Booking.php:424
+#: ../lib/GaletteEvents/Booking.php:413
 msgid "Booking added"
 msgstr "Booking added"
 
-#: ../lib/GaletteEvents/Booking.php:428
+#: ../lib/GaletteEvents/Booking.php:417
 msgid "Fail to add new booking."
 msgstr "Fail to add new booking."
 
-#: ../lib/GaletteEvents/Booking.php:446
+#: ../lib/GaletteEvents/Booking.php:435
 msgid "Booking updated"
 msgstr "Booking updated"
 
@@ -93,7 +97,7 @@ msgstr "An error occurred while storing the booking."
 msgid "Do not forget to store the booking"
 msgstr "Do not forget to store the booking"
 
-#. TRANS: first parameter is the member name, second the event name.
+#. TRANS: %1$s is the member name, %2$s the event name.
 #: ../lib/GaletteEvents/Controllers/Crud/BookingsController.php:648
 #, php-format
 msgid "Remove booking for %1$s on %2$s"
@@ -119,7 +123,8 @@ msgstr "Activity has been modified."
 msgid "An error occurred while storing the activity."
 msgstr "An error occurred while storing the activity."
 
-#: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:355
+#. TRANS %1$s is activity name
+#: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:348
 #, php-format
 msgid "Remove activity %1$s"
 msgstr "Remove activity %1$s"
@@ -168,7 +173,7 @@ msgstr "Event has been modified."
 msgid "An error occurred while storing the event."
 msgstr "An error occurred while storing the event."
 
-#. TRANS: first parameter is the event name
+#. TRANS: %1$s is the event name
 #: ../lib/GaletteEvents/Controllers/Crud/EventsController.php:514
 #, php-format
 msgid "Remove event '%1$s'\""
@@ -224,16 +229,17 @@ msgstr "Location:"
 msgid "Comment:"
 msgstr "Comment:"
 
-#: ../lib/GaletteEvents/Repository/Events.php:236
+#. TRANS: %1$s is the number of paid attendees
+#: ../lib/GaletteEvents/Repository/Events.php:237
 #, php-format
 msgid "%1$s paid"
 msgstr "%1$s paid"
 
-#: ../lib/GaletteEvents/Repository/Events.php:241
+#: ../lib/GaletteEvents/Repository/Events.php:242
 msgid "Attendees:"
 msgstr "Attendees:"
 
-#: ../lib/GaletteEvents/Repository/Events.php:249
+#: ../lib/GaletteEvents/Repository/Events.php:250
 #: ../lib/GaletteEvents/PluginGaletteEvents.php:113
 #: ../tempcache/event.html.twig:166 ../tempcache/booking.html.twig:213
 msgid "Activities"
@@ -251,31 +257,31 @@ msgstr "Begin date"
 msgid "End date"
 msgstr "End date"
 
-#: ../lib/GaletteEvents/Event.php:266
+#: ../lib/GaletteEvents/Event.php:261
 msgid "End date must be later or equal to begin date"
 msgstr "End date must be later or equal to begin date"
 
-#: ../lib/GaletteEvents/Event.php:272 ../lib/GaletteEvents/Activity.php:194
+#: ../lib/GaletteEvents/Event.php:267 ../lib/GaletteEvents/Activity.php:193
 msgid "Name is mandatory"
 msgstr "Name is mandatory"
 
-#: ../lib/GaletteEvents/Event.php:289
+#: ../lib/GaletteEvents/Event.php:284
 msgid "Please select a group you own!"
 msgstr "Please select a group you own!"
 
-#: ../lib/GaletteEvents/Event.php:296
+#: ../lib/GaletteEvents/Event.php:291
 msgid "Town is mandatory"
 msgstr "Town is mandatory"
 
-#: ../lib/GaletteEvents/Event.php:426
+#: ../lib/GaletteEvents/Event.php:421
 msgid "Event added"
 msgstr "Event added"
 
-#: ../lib/GaletteEvents/Event.php:430
+#: ../lib/GaletteEvents/Event.php:425
 msgid "Fail to add new event."
 msgstr "Fail to add new event."
 
-#: ../lib/GaletteEvents/Event.php:448
+#: ../lib/GaletteEvents/Event.php:443
 msgid "Event updated"
 msgstr "Event updated"
 
@@ -298,21 +304,21 @@ msgstr "Bookings"
 msgid "New event booking"
 msgstr "New event booking"
 
-#: ../lib/GaletteEvents/Activity.php:263
+#: ../lib/GaletteEvents/Activity.php:262
 msgid "Activity added"
 msgstr "Activity added"
 
-#: ../lib/GaletteEvents/Activity.php:268
+#: ../lib/GaletteEvents/Activity.php:267
 msgid "Fail to add new activity."
 msgstr "Fail to add new activity."
 
-#: ../lib/GaletteEvents/Activity.php:286
+#: ../lib/GaletteEvents/Activity.php:285
 msgid "Activity updated"
 msgstr "Activity updated"
 
 #: ../tempcache/event.html.twig:63 ../tempcache/activity.html.twig:63
-msgid "General informations"
-msgstr "General informations"
+msgid "General information"
+msgstr "General information"
 
 #: ../tempcache/event.html.twig:70
 msgid "Is open"
@@ -386,8 +392,8 @@ msgid "Please choose an activity to remove"
 msgstr "Please choose an activity to remove"
 
 #: ../tempcache/booking.html.twig:63
-msgid "Booking informations"
-msgstr "Booking informations"
+msgid "Booking information"
+msgstr "Booking information"
 
 #: ../tempcache/booking.html.twig:70 ../tempcache/bookings.html.twig:138
 #: ../tempcache/bookings.html.twig:414
@@ -403,8 +409,8 @@ msgid "No activity for selected event"
 msgstr "No activity for selected event"
 
 #: ../tempcache/booking.html.twig:280
-msgid "Financial informations"
-msgstr "Financial informations"
+msgid "Financial information"
+msgstr "Financial information"
 
 #: ../tempcache/booking.html.twig:287 ../tempcache/bookings.html.twig:138
 #: ../tempcache/bookings.html.twig:268 ../tempcache/bookings.html.twig:423
@@ -526,11 +532,13 @@ msgstr "Active"
 msgid "Inactive"
 msgstr "Inactive"
 
-#: ../tempcache/activities.html.twig:203
-msgid "%1$s: edit informations"
-msgstr "%1$s: edit informations"
+#: ../tempcache/activities.html.twig:203 ../tempcache/events.html.twig:253
+#, php-format
+msgid "%1$s: edit information"
+msgstr "%1$s: edit information"
 
-#: ../tempcache/activities.html.twig:205
+#: ../tempcache/activities.html.twig:205 ../tempcache/events.html.twig:266
+#, php-format
 msgid "%1$s: remove from database"
 msgstr "%1$s: remove from database"
 
@@ -574,16 +582,6 @@ msgstr "%1$s: export bookings as CSV"
 #, php-format
 msgid "%1$s: show bookings"
 msgstr "%1$s: show bookings"
-
-#: ../tempcache/events.html.twig:253
-#, php-format
-msgid "%1$s: edit informations"
-msgstr "%1$s: edit informations"
-
-#: ../tempcache/events.html.twig:266
-#, php-format
-msgid "%1$s: remove from database"
-msgstr "%1$s: remove from database"
 
 #: ../tempcache/events.html.twig:311
 msgid "No event has been found"

--- a/lang/events_es.utf8.po
+++ b/lang/events_es.utf8.po
@@ -29,8 +29,8 @@ msgid "Event is mandatory"
 msgstr "Evento es obligatorio"
 
 #: ../lib/GaletteEvents/Booking.php:221
-msgid "%activity is mandatory for this event!"
-msgstr "¡ %activity es obligatorio para este evento !"
+msgid "%1$s is mandatory for this event!"
+msgstr "¡ %1$s es obligatorio para este evento !"
 
 #: ../lib/GaletteEvents/Booking.php:255
 msgid "Please specify amount if booking has been paid ;)"
@@ -53,8 +53,8 @@ msgid "booking date"
 msgstr "fecha de reserva"
 
 #: ../lib/GaletteEvents/Booking.php:357
-msgid "A booking already exists for %member in %event"
-msgstr "Ya existe una reserva para %member en %event"
+msgid "A booking already exists for %1$s in %2$s"
+msgstr "Ya existe una reserva para %1$s en %2$s"
 
 #: ../lib/GaletteEvents/Booking.php:424
 msgid "Booking added"
@@ -449,10 +449,10 @@ msgstr "Exportar reservas seleccionadas como CSV"
 
 #: ../tempcache/bookings.html.twig:90
 #, php-format
-msgid "%count booking"
-msgid_plural "%count bookings"
-msgstr[0] "%count reserva"
-msgstr[1] "%count reservas"
+msgid "%1$s booking"
+msgid_plural "%1$s bookings"
+msgstr[0] "%1$s reserva"
+msgstr[1] "%1$s reservas"
 
 #: ../tempcache/bookings.html.twig:118 ../tempcache/calendar.html.twig:119
 msgid "New booking"
@@ -507,10 +507,10 @@ msgstr "No se ha encontrado ninguna reserva"
 
 #: ../tempcache/activities.html.twig:61
 #, php-format
-msgid "%count activity"
-msgid_plural "%count activities"
-msgstr[0] "%count actividad"
-msgstr[1] "%count actividades"
+msgid "%1$s activity"
+msgid_plural "%1$s activities"
+msgstr[0] "%1$s actividad"
+msgstr[1] "%1$s actividades"
 
 #: ../tempcache/activities.html.twig:88
 msgid "New activity"
@@ -534,12 +534,12 @@ msgid "Inactive"
 msgstr "Inactiva"
 
 #: ../tempcache/activities.html.twig:203
-msgid "%activity: edit informations"
-msgstr "%activity: editar información"
+msgid "%1$s: edit informations"
+msgstr "%1$s: editar información"
 
 #: ../tempcache/activities.html.twig:205
-msgid "%activity: remove from database"
-msgstr "%activity: quitar desde BdD"
+msgid "%1$s: remove from database"
+msgstr "%1$s: quitar desde BdD"
 
 #: ../tempcache/activities.html.twig:241
 msgid "No activity has been found"
@@ -547,10 +547,10 @@ msgstr "No se ha encontrado ninguna actividad"
 
 #: ../tempcache/events.html.twig:61
 #, php-format
-msgid "%count event"
-msgid_plural "%count events"
-msgstr[0] "%count evento"
-msgstr[1] "%count eventos"
+msgid "%1$s event"
+msgid_plural "%1$s events"
+msgstr[0] "%1$s evento"
+msgstr[1] "%1$s eventos"
 
 #: ../tempcache/events.html.twig:88
 msgid "New event"
@@ -574,23 +574,23 @@ msgstr "Evento cerrado"
 
 #: ../tempcache/events.html.twig:233
 #, php-format
-msgid "%eventname: export bookings as CSV"
-msgstr "Evento %eventname: exportar reservas como *.cvs"
+msgid "%1$s: export bookings as CSV"
+msgstr "Evento %1$s: exportar reservas como *.cvs"
 
 #: ../tempcache/events.html.twig:243
 #, php-format
-msgid "%eventname: show bookings"
-msgstr "evento %eventname: mostrar reservas"
+msgid "%1$s: show bookings"
+msgstr "evento %1$s: mostrar reservas"
 
 #: ../tempcache/events.html.twig:253
 #, php-format
-msgid "%eventname: edit informations"
-msgstr "evento %eventname: editar informaciones"
+msgid "%1$s: edit informations"
+msgstr "evento %1$s: editar informaciones"
 
 #: ../tempcache/events.html.twig:266
 #, php-format
-msgid "%eventname: remove from database"
-msgstr "evento %eventname: eliminar de la base de datos"
+msgid "%1$s: remove from database"
+msgstr "evento %1$s: eliminar de la base de datos"
 
 #: ../tempcache/events.html.twig:311
 msgid "No event has been found"

--- a/lang/events_es.utf8.po
+++ b/lang/events_es.utf8.po
@@ -123,7 +123,7 @@ msgid "Activity has been modified."
 msgstr "Ha sido modificada la actividad."
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:263
-msgid "An error occured while storing the activity."
+msgid "An error occurred while storing the activity."
 msgstr "Ha ocurrido un error mientras almacenaba la actividad."
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:355
@@ -172,7 +172,7 @@ msgid "Event has been modified."
 msgstr "Evento ha sido modificado."
 
 #: ../lib/GaletteEvents/Controllers/Crud/EventsController.php:414
-msgid "An error occured while storing the event."
+msgid "An error occurred while storing the event."
 msgstr "Ha ocurrido un error al almacenar el evento."
 
 #. TRANS: first parameter is the event name

--- a/lang/events_es.utf8.po
+++ b/lang/events_es.utf8.po
@@ -213,7 +213,7 @@ msgstr "listado de reservas"
 
 #: ../lib/GaletteEvents/Repository/Events.php:213
 msgid "Event information"
-msgstr "Información de evento"
+msgstr "Informaciones de evento"
 
 #: ../lib/GaletteEvents/Repository/Events.php:217
 msgid "Start date:"
@@ -318,8 +318,8 @@ msgid "Activity updated"
 msgstr "Actividad actualizada"
 
 #: ../tempcache/event.html.twig:63 ../tempcache/activity.html.twig:63
-msgid "General informations"
-msgstr "Información general"
+msgid "General information"
+msgstr "Informaciones general"
 
 #: ../tempcache/event.html.twig:70
 msgid "Is open"
@@ -393,8 +393,8 @@ msgid "Please choose an activity to remove"
 msgstr "Por favor, elija una actividad para eliminar"
 
 #: ../tempcache/booking.html.twig:63
-msgid "Booking informations"
-msgstr "Información de reserva"
+msgid "Booking information"
+msgstr "Informaciones de reserva"
 
 #: ../tempcache/booking.html.twig:70 ../tempcache/bookings.html.twig:138
 #: ../tempcache/bookings.html.twig:414
@@ -410,7 +410,7 @@ msgid "No activity for selected event"
 msgstr "Ninguna actividad para evento seleccionado"
 
 #: ../tempcache/booking.html.twig:280
-msgid "Financial informations"
+msgid "Financial information"
 msgstr "Informaciones financieras"
 
 #: ../tempcache/booking.html.twig:287 ../tempcache/bookings.html.twig:138
@@ -534,8 +534,8 @@ msgid "Inactive"
 msgstr "Inactiva"
 
 #: ../tempcache/activities.html.twig:203
-msgid "%1$s: edit informations"
-msgstr "%1$s: editar información"
+msgid "%1$s: edit information"
+msgstr "%1$s: editar informaciones"
 
 #: ../tempcache/activities.html.twig:205
 msgid "%1$s: remove from database"
@@ -581,11 +581,6 @@ msgstr "Evento %1$s: exportar reservas como *.cvs"
 #, php-format
 msgid "%1$s: show bookings"
 msgstr "evento %1$s: mostrar reservas"
-
-#: ../tempcache/events.html.twig:253
-#, php-format
-msgid "%1$s: edit informations"
-msgstr "evento %1$s: editar informaciones"
 
 #: ../tempcache/events.html.twig:266
 #, php-format

--- a/lang/events_fr_FR.utf8.po
+++ b/lang/events_fr_FR.utf8.po
@@ -115,7 +115,7 @@ msgid "Activity has been modified."
 msgstr "L'activité a été modifiée."
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:263
-msgid "An error occured while storing the activity."
+msgid "An error occurred while storing the activity."
 msgstr "Une erreur est survenue à l'enregistrement de l'activité."
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:355
@@ -164,7 +164,7 @@ msgid "Event has been modified."
 msgstr "L'évènement a été modifié."
 
 #: ../lib/GaletteEvents/Controllers/Crud/EventsController.php:414
-msgid "An error occured while storing the event."
+msgid "An error occurred while storing the event."
 msgstr "Une erreur est survenue à l'enregistrement de l'évènement."
 
 #. TRANS: first parameter is the event name
@@ -651,7 +651,7 @@ msgstr "Aujourd'hui"
 #~ msgstr ""
 #~ "L'identifiant de l'évènement ne peut être vide pour la route d'édition !"
 
-#~ msgid "An error occured trying to remove event %name :/"
+#~ msgid "An error occurred trying to remove event %name :/"
 #~ msgstr "Une erreur est survenue à la suppression de l'évènement %name :/"
 
 #~ msgid "Event %name has been successfully deleted."
@@ -662,7 +662,7 @@ msgstr "Aujourd'hui"
 #~ "L'identifiant de la réservation ne peut être vide pour la route "
 #~ "d'édition !"
 
-#~ msgid "An error occured trying to remove booking :/"
+#~ msgid "An error occurred trying to remove booking :/"
 #~ msgstr "Une erreur est survenue à la suppression de la réservation :/"
 
 #~ msgid "Booking has been successfully deleted."
@@ -677,7 +677,7 @@ msgstr "Aujourd'hui"
 #~ "L'activité %name est référencée dans %1$s évènements, elle ne peut être "
 #~ "supprimée."
 
-#~ msgid "An error occured trying to remove activity %name :/"
+#~ msgid "An error occurred trying to remove activity %name :/"
 #~ msgstr "Une erreur est survenue à la suppression de l'activité %name :/"
 
 #~ msgid "Activity %name has been successfully deleted."

--- a/lang/events_fr_FR.utf8.po
+++ b/lang/events_fr_FR.utf8.po
@@ -310,7 +310,7 @@ msgid "Activity updated"
 msgstr "Activité mise à jour"
 
 #: ../tempcache/event.html.twig:63 ../tempcache/activity.html.twig:63
-msgid "General informations"
+msgid "General information"
 msgstr "Informations générales"
 
 #: ../tempcache/event.html.twig:70
@@ -385,7 +385,7 @@ msgid "Please choose an activity to remove"
 msgstr "Veuillez choisir une activité à supprimer"
 
 #: ../tempcache/booking.html.twig:63
-msgid "Booking informations"
+msgid "Booking information"
 msgstr "Informations réservation"
 
 #: ../tempcache/booking.html.twig:70 ../tempcache/bookings.html.twig:138
@@ -402,7 +402,7 @@ msgid "No activity for selected event"
 msgstr "Aucune activité pour l'évènement sélectioné"
 
 #: ../tempcache/booking.html.twig:280
-msgid "Financial informations"
+msgid "Financial information"
 msgstr "Informations financières"
 
 #: ../tempcache/booking.html.twig:287 ../tempcache/bookings.html.twig:138
@@ -526,7 +526,7 @@ msgid "Inactive"
 msgstr "Inactif"
 
 #: ../tempcache/activities.html.twig:203
-msgid "%1$s: edit informations"
+msgid "%1$s: edit information"
 msgstr "%1$s : modifier les informations"
 
 #: ../tempcache/activities.html.twig:205
@@ -573,11 +573,6 @@ msgstr "%1$s : exporter les réservations en CSV"
 #, php-format
 msgid "%1$s: show bookings"
 msgstr "%1$s : voir les réservations"
-
-#: ../tempcache/events.html.twig:253
-#, php-format
-msgid "%1$s: edit informations"
-msgstr "%1$s : modifier les informations"
 
 #: ../tempcache/events.html.twig:266
 #, php-format

--- a/lang/events_fr_FR.utf8.po
+++ b/lang/events_fr_FR.utf8.po
@@ -21,8 +21,8 @@ msgid "Event is mandatory"
 msgstr "L'évènement est requis"
 
 #: ../lib/GaletteEvents/Booking.php:221
-msgid "%activity is mandatory for this event!"
-msgstr "%activity est obligatoire pour cet évènement !"
+msgid "%1$s is mandatory for this event!"
+msgstr "%1$s est obligatoire pour cet évènement !"
 
 #: ../lib/GaletteEvents/Booking.php:255
 msgid "Please specify amount if booking has been paid ;)"
@@ -45,8 +45,8 @@ msgid "booking date"
 msgstr "date de réservation"
 
 #: ../lib/GaletteEvents/Booking.php:357
-msgid "A booking already exists for %member in %event"
-msgstr "Une réservation existe déjà pour l'adhérent %member dans %event"
+msgid "A booking already exists for %1$s in %2$s"
+msgstr "Une réservation existe déjà pour %1$s dans %2$s"
 
 #: ../lib/GaletteEvents/Booking.php:424
 msgid "Booking added"
@@ -441,10 +441,10 @@ msgstr "Export des réservations sélectionnées en CSV"
 
 #: ../tempcache/bookings.html.twig:90
 #, php-format
-msgid "%count booking"
-msgid_plural "%count bookings"
-msgstr[0] "%count réservation"
-msgstr[1] "%count réservations"
+msgid "%1$s booking"
+msgid_plural "%1$s bookings"
+msgstr[0] "%1$s réservation"
+msgstr[1] "%1$s réservations"
 
 #: ../tempcache/bookings.html.twig:118 ../tempcache/calendar.html.twig:119
 msgid "New booking"
@@ -499,10 +499,10 @@ msgstr "Aucune réservation trouvée"
 
 #: ../tempcache/activities.html.twig:61
 #, php-format
-msgid "%count activity"
-msgid_plural "%count activities"
-msgstr[0] "%count activité"
-msgstr[1] "%count activités"
+msgid "%1$s activity"
+msgid_plural "%1$s activities"
+msgstr[0] "%1$s activité"
+msgstr[1] "%1$s activités"
 
 #: ../tempcache/activities.html.twig:88
 msgid "New activity"
@@ -526,12 +526,12 @@ msgid "Inactive"
 msgstr "Inactif"
 
 #: ../tempcache/activities.html.twig:203
-msgid "%activity: edit informations"
-msgstr "%activity : modifier les informations"
+msgid "%1$s: edit informations"
+msgstr "%1$s : modifier les informations"
 
 #: ../tempcache/activities.html.twig:205
-msgid "%activity: remove from database"
-msgstr "%activity : supprimer de la base de données"
+msgid "%1$s: remove from database"
+msgstr "%1$s : supprimer de la base de données"
 
 #: ../tempcache/activities.html.twig:241
 msgid "No activity has been found"
@@ -539,10 +539,10 @@ msgstr "Aucune activité trouvée"
 
 #: ../tempcache/events.html.twig:61
 #, php-format
-msgid "%count event"
-msgid_plural "%count events"
-msgstr[0] "%count évènement"
-msgstr[1] "%count évènements"
+msgid "%1$s event"
+msgid_plural "%1$s events"
+msgstr[0] "%1$s évènement"
+msgstr[1] "%1$s évènements"
 
 #: ../tempcache/events.html.twig:88
 msgid "New event"
@@ -566,23 +566,23 @@ msgstr "L'évènement est fermé"
 
 #: ../tempcache/events.html.twig:233
 #, php-format
-msgid "%eventname: export bookings as CSV"
-msgstr "%eventname : exporter les réservations en CSV"
+msgid "%1$s: export bookings as CSV"
+msgstr "%1$s : exporter les réservations en CSV"
 
 #: ../tempcache/events.html.twig:243
 #, php-format
-msgid "%eventname: show bookings"
-msgstr "%eventname : voir les réservations"
+msgid "%1$s: show bookings"
+msgstr "%1$s : voir les réservations"
 
 #: ../tempcache/events.html.twig:253
 #, php-format
-msgid "%eventname: edit informations"
-msgstr "%eventname : modifier les informations"
+msgid "%1$s: edit informations"
+msgstr "%1$s : modifier les informations"
 
 #: ../tempcache/events.html.twig:266
 #, php-format
-msgid "%eventname: remove from database"
-msgstr "%eventname : supprimer de la base de données"
+msgid "%1$s: remove from database"
+msgstr "%1$s : supprimer de la base de données"
 
 #: ../tempcache/events.html.twig:311
 msgid "No event has been found"
@@ -672,9 +672,9 @@ msgstr "Aujourd'hui"
 #~ msgstr ""
 #~ "L'identifiant de l'activité ne peut être vide pour la route d'édition !"
 
-#~ msgid "Activity %name is referenced in %count events, it cannot be removed."
+#~ msgid "Activity %name is referenced in %1$s events, it cannot be removed."
 #~ msgstr ""
-#~ "L'activité %name est référencée dans %count évènements, elle ne peut être "
+#~ "L'activité %name est référencée dans %1$s évènements, elle ne peut être "
 #~ "supprimée."
 
 #~ msgid "An error occured trying to remove activity %name :/"

--- a/lang/events_it_IT.utf8.po
+++ b/lang/events_it_IT.utf8.po
@@ -115,7 +115,7 @@ msgid "Activity has been modified."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:263
-msgid "An error occured while storing the activity."
+msgid "An error occurred while storing the activity."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:355
@@ -164,7 +164,7 @@ msgid "Event has been modified."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/EventsController.php:414
-msgid "An error occured while storing the event."
+msgid "An error occurred while storing the event."
 msgstr ""
 
 #. TRANS: first parameter is the event name

--- a/lang/events_it_IT.utf8.po
+++ b/lang/events_it_IT.utf8.po
@@ -21,7 +21,7 @@ msgid "Event is mandatory"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:221
-msgid "%activity is mandatory for this event!"
+msgid "%1$s is mandatory for this event!"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:255
@@ -45,7 +45,7 @@ msgid "booking date"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:357
-msgid "A booking already exists for %member in %event"
+msgid "A booking already exists for %1$s in %2$s"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:424
@@ -439,8 +439,8 @@ msgstr ""
 
 #: ../tempcache/bookings.html.twig:90
 #, php-format
-msgid "%count booking"
-msgid_plural "%count bookings"
+msgid "%1$s booking"
+msgid_plural "%1$s bookings"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -497,8 +497,8 @@ msgstr ""
 
 #: ../tempcache/activities.html.twig:61
 #, php-format
-msgid "%count activity"
-msgid_plural "%count activities"
+msgid "%1$s activity"
+msgid_plural "%1$s activities"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -524,11 +524,11 @@ msgid "Inactive"
 msgstr "Inattivo"
 
 #: ../tempcache/activities.html.twig:203
-msgid "%activity: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
-msgid "%activity: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:241
@@ -537,8 +537,8 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:61
 #, php-format
-msgid "%count event"
-msgid_plural "%count events"
+msgid "%1$s event"
+msgid_plural "%1$s events"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -564,22 +564,22 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:233
 #, php-format
-msgid "%eventname: export bookings as CSV"
+msgid "%1$s: export bookings as CSV"
 msgstr ""
 
 #: ../tempcache/events.html.twig:243
 #, php-format
-msgid "%eventname: show bookings"
+msgid "%1$s: show bookings"
 msgstr ""
 
 #: ../tempcache/events.html.twig:253
 #, php-format
-msgid "%eventname: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266
 #, php-format
-msgid "%eventname: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/events.html.twig:311

--- a/lang/events_it_IT.utf8.po
+++ b/lang/events_it_IT.utf8.po
@@ -310,7 +310,7 @@ msgid "Activity updated"
 msgstr ""
 
 #: ../tempcache/event.html.twig:63 ../tempcache/activity.html.twig:63
-msgid "General informations"
+msgid "General information"
 msgstr ""
 
 #: ../tempcache/event.html.twig:70
@@ -385,7 +385,7 @@ msgid "Please choose an activity to remove"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:63
-msgid "Booking informations"
+msgid "Booking information"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:70 ../tempcache/bookings.html.twig:138
@@ -402,7 +402,7 @@ msgid "No activity for selected event"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:280
-msgid "Financial informations"
+msgid "Financial information"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:287 ../tempcache/bookings.html.twig:138
@@ -524,7 +524,7 @@ msgid "Inactive"
 msgstr "Inattivo"
 
 #: ../tempcache/activities.html.twig:203
-msgid "%1$s: edit informations"
+msgid "%1$s: edit information"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
@@ -570,11 +570,6 @@ msgstr ""
 #: ../tempcache/events.html.twig:243
 #, php-format
 msgid "%1$s: show bookings"
-msgstr ""
-
-#: ../tempcache/events.html.twig:253
-#, php-format
-msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266

--- a/lang/events_nb_NO.utf8.po
+++ b/lang/events_nb_NO.utf8.po
@@ -17,7 +17,7 @@ msgid "Event is mandatory"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:221
-msgid "%activity is mandatory for this event!"
+msgid "%1$s is mandatory for this event!"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:255
@@ -41,7 +41,7 @@ msgid "booking date"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:357
-msgid "A booking already exists for %member in %event"
+msgid "A booking already exists for %1$s in %2$s"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:424
@@ -435,8 +435,8 @@ msgstr ""
 
 #: ../tempcache/bookings.html.twig:90
 #, php-format
-msgid "%count booking"
-msgid_plural "%count bookings"
+msgid "%1$s booking"
+msgid_plural "%1$s bookings"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -493,8 +493,8 @@ msgstr ""
 
 #: ../tempcache/activities.html.twig:61
 #, php-format
-msgid "%count activity"
-msgid_plural "%count activities"
+msgid "%1$s activity"
+msgid_plural "%1$s activities"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -520,11 +520,11 @@ msgid "Inactive"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:203
-msgid "%activity: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
-msgid "%activity: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:241
@@ -533,8 +533,8 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:61
 #, php-format
-msgid "%count event"
-msgid_plural "%count events"
+msgid "%1$s event"
+msgid_plural "%1$s events"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -560,22 +560,22 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:233
 #, php-format
-msgid "%eventname: export bookings as CSV"
+msgid "%1$s: export bookings as CSV"
 msgstr ""
 
 #: ../tempcache/events.html.twig:243
 #, php-format
-msgid "%eventname: show bookings"
+msgid "%1$s: show bookings"
 msgstr ""
 
 #: ../tempcache/events.html.twig:253
 #, php-format
-msgid "%eventname: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266
 #, php-format
-msgid "%eventname: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/events.html.twig:311

--- a/lang/events_nb_NO.utf8.po
+++ b/lang/events_nb_NO.utf8.po
@@ -306,7 +306,7 @@ msgid "Activity updated"
 msgstr ""
 
 #: ../tempcache/event.html.twig:63 ../tempcache/activity.html.twig:63
-msgid "General informations"
+msgid "General information"
 msgstr ""
 
 #: ../tempcache/event.html.twig:70
@@ -381,7 +381,7 @@ msgid "Please choose an activity to remove"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:63
-msgid "Booking informations"
+msgid "Booking information"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:70 ../tempcache/bookings.html.twig:138
@@ -398,7 +398,7 @@ msgid "No activity for selected event"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:280
-msgid "Financial informations"
+msgid "Financial information"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:287 ../tempcache/bookings.html.twig:138
@@ -520,7 +520,7 @@ msgid "Inactive"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:203
-msgid "%1$s: edit informations"
+msgid "%1$s: edit information"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
@@ -566,11 +566,6 @@ msgstr ""
 #: ../tempcache/events.html.twig:243
 #, php-format
 msgid "%1$s: show bookings"
-msgstr ""
-
-#: ../tempcache/events.html.twig:253
-#, php-format
-msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266

--- a/lang/events_nb_NO.utf8.po
+++ b/lang/events_nb_NO.utf8.po
@@ -111,7 +111,7 @@ msgid "Activity has been modified."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:263
-msgid "An error occured while storing the activity."
+msgid "An error occurred while storing the activity."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:355
@@ -160,7 +160,7 @@ msgid "Event has been modified."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/EventsController.php:414
-msgid "An error occured while storing the event."
+msgid "An error occurred while storing the event."
 msgstr ""
 
 #. TRANS: first parameter is the event name

--- a/lang/events_oc.utf8.po
+++ b/lang/events_oc.utf8.po
@@ -116,7 +116,7 @@ msgid "Activity has been modified."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:263
-msgid "An error occured while storing the activity."
+msgid "An error occurred while storing the activity."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:355
@@ -165,7 +165,7 @@ msgid "Event has been modified."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/EventsController.php:414
-msgid "An error occured while storing the event."
+msgid "An error occurred while storing the event."
 msgstr ""
 
 #. TRANS: first parameter is the event name

--- a/lang/events_oc.utf8.po
+++ b/lang/events_oc.utf8.po
@@ -22,7 +22,7 @@ msgid "Event is mandatory"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:221
-msgid "%activity is mandatory for this event!"
+msgid "%1$s is mandatory for this event!"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:255
@@ -46,7 +46,7 @@ msgid "booking date"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:357
-msgid "A booking already exists for %member in %event"
+msgid "A booking already exists for %1$s in %2$s"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:424
@@ -440,8 +440,8 @@ msgstr ""
 
 #: ../tempcache/bookings.html.twig:90
 #, php-format
-msgid "%count booking"
-msgid_plural "%count bookings"
+msgid "%1$s booking"
+msgid_plural "%1$s bookings"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -498,8 +498,8 @@ msgstr ""
 
 #: ../tempcache/activities.html.twig:61
 #, php-format
-msgid "%count activity"
-msgid_plural "%count activities"
+msgid "%1$s activity"
+msgid_plural "%1$s activities"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -525,11 +525,11 @@ msgid "Inactive"
 msgstr "Inactiu"
 
 #: ../tempcache/activities.html.twig:203
-msgid "%activity: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
-msgid "%activity: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:241
@@ -538,8 +538,8 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:61
 #, php-format
-msgid "%count event"
-msgid_plural "%count events"
+msgid "%1$s event"
+msgid_plural "%1$s events"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -565,22 +565,22 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:233
 #, php-format
-msgid "%eventname: export bookings as CSV"
+msgid "%1$s: export bookings as CSV"
 msgstr ""
 
 #: ../tempcache/events.html.twig:243
 #, php-format
-msgid "%eventname: show bookings"
+msgid "%1$s: show bookings"
 msgstr ""
 
 #: ../tempcache/events.html.twig:253
 #, php-format
-msgid "%eventname: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266
 #, php-format
-msgid "%eventname: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/events.html.twig:311

--- a/lang/events_oc.utf8.po
+++ b/lang/events_oc.utf8.po
@@ -311,7 +311,7 @@ msgid "Activity updated"
 msgstr ""
 
 #: ../tempcache/event.html.twig:63 ../tempcache/activity.html.twig:63
-msgid "General informations"
+msgid "General information"
 msgstr ""
 
 #: ../tempcache/event.html.twig:70
@@ -386,7 +386,7 @@ msgid "Please choose an activity to remove"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:63
-msgid "Booking informations"
+msgid "Booking information"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:70 ../tempcache/bookings.html.twig:138
@@ -403,7 +403,7 @@ msgid "No activity for selected event"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:280
-msgid "Financial informations"
+msgid "Financial information"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:287 ../tempcache/bookings.html.twig:138
@@ -525,7 +525,7 @@ msgid "Inactive"
 msgstr "Inactiu"
 
 #: ../tempcache/activities.html.twig:203
-msgid "%1$s: edit informations"
+msgid "%1$s: edit information"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
@@ -571,11 +571,6 @@ msgstr ""
 #: ../tempcache/events.html.twig:243
 #, php-format
 msgid "%1$s: show bookings"
-msgstr ""
-
-#: ../tempcache/events.html.twig:253
-#, php-format
-msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266

--- a/lang/events_ota.utf8.po
+++ b/lang/events_ota.utf8.po
@@ -17,7 +17,7 @@ msgid "Event is mandatory"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:221
-msgid "%activity is mandatory for this event!"
+msgid "%1$s is mandatory for this event!"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:255
@@ -41,7 +41,7 @@ msgid "booking date"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:357
-msgid "A booking already exists for %member in %event"
+msgid "A booking already exists for %1$s in %2$s"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:424
@@ -435,8 +435,8 @@ msgstr ""
 
 #: ../tempcache/bookings.html.twig:90
 #, php-format
-msgid "%count booking"
-msgid_plural "%count bookings"
+msgid "%1$s booking"
+msgid_plural "%1$s bookings"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -493,8 +493,8 @@ msgstr ""
 
 #: ../tempcache/activities.html.twig:61
 #, php-format
-msgid "%count activity"
-msgid_plural "%count activities"
+msgid "%1$s activity"
+msgid_plural "%1$s activities"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -520,11 +520,11 @@ msgid "Inactive"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:203
-msgid "%activity: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
-msgid "%activity: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:241
@@ -533,8 +533,8 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:61
 #, php-format
-msgid "%count event"
-msgid_plural "%count events"
+msgid "%1$s event"
+msgid_plural "%1$s events"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -560,22 +560,22 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:233
 #, php-format
-msgid "%eventname: export bookings as CSV"
+msgid "%1$s: export bookings as CSV"
 msgstr ""
 
 #: ../tempcache/events.html.twig:243
 #, php-format
-msgid "%eventname: show bookings"
+msgid "%1$s: show bookings"
 msgstr ""
 
 #: ../tempcache/events.html.twig:253
 #, php-format
-msgid "%eventname: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266
 #, php-format
-msgid "%eventname: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/events.html.twig:311

--- a/lang/events_ota.utf8.po
+++ b/lang/events_ota.utf8.po
@@ -306,7 +306,7 @@ msgid "Activity updated"
 msgstr ""
 
 #: ../tempcache/event.html.twig:63 ../tempcache/activity.html.twig:63
-msgid "General informations"
+msgid "General information"
 msgstr ""
 
 #: ../tempcache/event.html.twig:70
@@ -381,7 +381,7 @@ msgid "Please choose an activity to remove"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:63
-msgid "Booking informations"
+msgid "Booking information"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:70 ../tempcache/bookings.html.twig:138
@@ -398,7 +398,7 @@ msgid "No activity for selected event"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:280
-msgid "Financial informations"
+msgid "Financial information"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:287 ../tempcache/bookings.html.twig:138
@@ -520,7 +520,7 @@ msgid "Inactive"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:203
-msgid "%1$s: edit informations"
+msgid "%1$s: edit information"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
@@ -566,11 +566,6 @@ msgstr ""
 #: ../tempcache/events.html.twig:243
 #, php-format
 msgid "%1$s: show bookings"
-msgstr ""
-
-#: ../tempcache/events.html.twig:253
-#, php-format
-msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266

--- a/lang/events_ota.utf8.po
+++ b/lang/events_ota.utf8.po
@@ -111,7 +111,7 @@ msgid "Activity has been modified."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:263
-msgid "An error occured while storing the activity."
+msgid "An error occurred while storing the activity."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:355
@@ -160,7 +160,7 @@ msgid "Event has been modified."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/EventsController.php:414
-msgid "An error occured while storing the event."
+msgid "An error occurred while storing the event."
 msgstr ""
 
 #. TRANS: first parameter is the event name

--- a/lang/events_ru.utf8.po
+++ b/lang/events_ru.utf8.po
@@ -313,7 +313,7 @@ msgid "Activity updated"
 msgstr ""
 
 #: ../tempcache/event.html.twig:63 ../tempcache/activity.html.twig:63
-msgid "General informations"
+msgid "General information"
 msgstr ""
 
 #: ../tempcache/event.html.twig:70
@@ -388,7 +388,7 @@ msgid "Please choose an activity to remove"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:63
-msgid "Booking informations"
+msgid "Booking information"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:70 ../tempcache/bookings.html.twig:138
@@ -405,7 +405,7 @@ msgid "No activity for selected event"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:280
-msgid "Financial informations"
+msgid "Financial information"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:287 ../tempcache/bookings.html.twig:138
@@ -527,7 +527,7 @@ msgid "Inactive"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:203
-msgid "%1$s: edit informations"
+msgid "%1$s: edit information"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
@@ -573,11 +573,6 @@ msgstr ""
 #: ../tempcache/events.html.twig:243
 #, php-format
 msgid "%1$s: show bookings"
-msgstr ""
-
-#: ../tempcache/events.html.twig:253
-#, php-format
-msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266

--- a/lang/events_ru.utf8.po
+++ b/lang/events_ru.utf8.po
@@ -118,7 +118,7 @@ msgid "Activity has been modified."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:263
-msgid "An error occured while storing the activity."
+msgid "An error occurred while storing the activity."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:355
@@ -167,7 +167,7 @@ msgid "Event has been modified."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/EventsController.php:414
-msgid "An error occured while storing the event."
+msgid "An error occurred while storing the event."
 msgstr ""
 
 #. TRANS: first parameter is the event name

--- a/lang/events_ru.utf8.po
+++ b/lang/events_ru.utf8.po
@@ -24,7 +24,7 @@ msgid "Event is mandatory"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:221
-msgid "%activity is mandatory for this event!"
+msgid "%1$s is mandatory for this event!"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:255
@@ -48,7 +48,7 @@ msgid "booking date"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:357
-msgid "A booking already exists for %member in %event"
+msgid "A booking already exists for %1$s in %2$s"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:424
@@ -442,8 +442,8 @@ msgstr ""
 
 #: ../tempcache/bookings.html.twig:90
 #, php-format
-msgid "%count booking"
-msgid_plural "%count bookings"
+msgid "%1$s booking"
+msgid_plural "%1$s bookings"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -500,8 +500,8 @@ msgstr ""
 
 #: ../tempcache/activities.html.twig:61
 #, php-format
-msgid "%count activity"
-msgid_plural "%count activities"
+msgid "%1$s activity"
+msgid_plural "%1$s activities"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -527,11 +527,11 @@ msgid "Inactive"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:203
-msgid "%activity: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
-msgid "%activity: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:241
@@ -540,8 +540,8 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:61
 #, php-format
-msgid "%count event"
-msgid_plural "%count events"
+msgid "%1$s event"
+msgid_plural "%1$s events"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -567,22 +567,22 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:233
 #, php-format
-msgid "%eventname: export bookings as CSV"
+msgid "%1$s: export bookings as CSV"
 msgstr ""
 
 #: ../tempcache/events.html.twig:243
 #, php-format
-msgid "%eventname: show bookings"
+msgid "%1$s: show bookings"
 msgstr ""
 
 #: ../tempcache/events.html.twig:253
 #, php-format
-msgid "%eventname: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266
 #, php-format
-msgid "%eventname: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/events.html.twig:311

--- a/lang/events_si.utf8.po
+++ b/lang/events_si.utf8.po
@@ -17,7 +17,7 @@ msgid "Event is mandatory"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:221
-msgid "%activity is mandatory for this event!"
+msgid "%1$s is mandatory for this event!"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:255
@@ -41,7 +41,7 @@ msgid "booking date"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:357
-msgid "A booking already exists for %member in %event"
+msgid "A booking already exists for %1$s in %2$s"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:424
@@ -435,8 +435,8 @@ msgstr ""
 
 #: ../tempcache/bookings.html.twig:90
 #, php-format
-msgid "%count booking"
-msgid_plural "%count bookings"
+msgid "%1$s booking"
+msgid_plural "%1$s bookings"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -493,8 +493,8 @@ msgstr ""
 
 #: ../tempcache/activities.html.twig:61
 #, php-format
-msgid "%count activity"
-msgid_plural "%count activities"
+msgid "%1$s activity"
+msgid_plural "%1$s activities"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -520,11 +520,11 @@ msgid "Inactive"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:203
-msgid "%activity: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
-msgid "%activity: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:241
@@ -533,8 +533,8 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:61
 #, php-format
-msgid "%count event"
-msgid_plural "%count events"
+msgid "%1$s event"
+msgid_plural "%1$s events"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -560,22 +560,22 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:233
 #, php-format
-msgid "%eventname: export bookings as CSV"
+msgid "%1$s: export bookings as CSV"
 msgstr ""
 
 #: ../tempcache/events.html.twig:243
 #, php-format
-msgid "%eventname: show bookings"
+msgid "%1$s: show bookings"
 msgstr ""
 
 #: ../tempcache/events.html.twig:253
 #, php-format
-msgid "%eventname: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266
 #, php-format
-msgid "%eventname: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/events.html.twig:311

--- a/lang/events_si.utf8.po
+++ b/lang/events_si.utf8.po
@@ -306,7 +306,7 @@ msgid "Activity updated"
 msgstr ""
 
 #: ../tempcache/event.html.twig:63 ../tempcache/activity.html.twig:63
-msgid "General informations"
+msgid "General information"
 msgstr ""
 
 #: ../tempcache/event.html.twig:70
@@ -381,7 +381,7 @@ msgid "Please choose an activity to remove"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:63
-msgid "Booking informations"
+msgid "Booking information"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:70 ../tempcache/bookings.html.twig:138
@@ -398,7 +398,7 @@ msgid "No activity for selected event"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:280
-msgid "Financial informations"
+msgid "Financial information"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:287 ../tempcache/bookings.html.twig:138
@@ -520,7 +520,7 @@ msgid "Inactive"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:203
-msgid "%1$s: edit informations"
+msgid "%1$s: edit information"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
@@ -566,11 +566,6 @@ msgstr ""
 #: ../tempcache/events.html.twig:243
 #, php-format
 msgid "%1$s: show bookings"
-msgstr ""
-
-#: ../tempcache/events.html.twig:253
-#, php-format
-msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266

--- a/lang/events_si.utf8.po
+++ b/lang/events_si.utf8.po
@@ -111,7 +111,7 @@ msgid "Activity has been modified."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:263
-msgid "An error occured while storing the activity."
+msgid "An error occurred while storing the activity."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:355
@@ -160,7 +160,7 @@ msgid "Event has been modified."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/EventsController.php:414
-msgid "An error occured while storing the event."
+msgid "An error occurred while storing the event."
 msgstr ""
 
 #. TRANS: first parameter is the event name

--- a/lang/events_tr.utf8.po
+++ b/lang/events_tr.utf8.po
@@ -20,7 +20,7 @@ msgid "Event is mandatory"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:221
-msgid "%activity is mandatory for this event!"
+msgid "%1$s is mandatory for this event!"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:255
@@ -44,7 +44,7 @@ msgid "booking date"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:357
-msgid "A booking already exists for %member in %event"
+msgid "A booking already exists for %1$s in %2$s"
 msgstr ""
 
 #: ../lib/GaletteEvents/Booking.php:424
@@ -438,8 +438,8 @@ msgstr ""
 
 #: ../tempcache/bookings.html.twig:90
 #, php-format
-msgid "%count booking"
-msgid_plural "%count bookings"
+msgid "%1$s booking"
+msgid_plural "%1$s bookings"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -496,8 +496,8 @@ msgstr ""
 
 #: ../tempcache/activities.html.twig:61
 #, php-format
-msgid "%count activity"
-msgid_plural "%count activities"
+msgid "%1$s activity"
+msgid_plural "%1$s activities"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -523,11 +523,11 @@ msgid "Inactive"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:203
-msgid "%activity: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
-msgid "%activity: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:241
@@ -536,8 +536,8 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:61
 #, php-format
-msgid "%count event"
-msgid_plural "%count events"
+msgid "%1$s event"
+msgid_plural "%1$s events"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -563,22 +563,22 @@ msgstr ""
 
 #: ../tempcache/events.html.twig:233
 #, php-format
-msgid "%eventname: export bookings as CSV"
+msgid "%1$s: export bookings as CSV"
 msgstr ""
 
 #: ../tempcache/events.html.twig:243
 #, php-format
-msgid "%eventname: show bookings"
+msgid "%1$s: show bookings"
 msgstr ""
 
 #: ../tempcache/events.html.twig:253
 #, php-format
-msgid "%eventname: edit informations"
+msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266
 #, php-format
-msgid "%eventname: remove from database"
+msgid "%1$s: remove from database"
 msgstr ""
 
 #: ../tempcache/events.html.twig:311

--- a/lang/events_tr.utf8.po
+++ b/lang/events_tr.utf8.po
@@ -114,7 +114,7 @@ msgid "Activity has been modified."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:263
-msgid "An error occured while storing the activity."
+msgid "An error occurred while storing the activity."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:355
@@ -163,7 +163,7 @@ msgid "Event has been modified."
 msgstr ""
 
 #: ../lib/GaletteEvents/Controllers/Crud/EventsController.php:414
-msgid "An error occured while storing the event."
+msgid "An error occurred while storing the event."
 msgstr ""
 
 #. TRANS: first parameter is the event name

--- a/lang/events_tr.utf8.po
+++ b/lang/events_tr.utf8.po
@@ -309,7 +309,7 @@ msgid "Activity updated"
 msgstr ""
 
 #: ../tempcache/event.html.twig:63 ../tempcache/activity.html.twig:63
-msgid "General informations"
+msgid "General information"
 msgstr ""
 
 #: ../tempcache/event.html.twig:70
@@ -384,7 +384,7 @@ msgid "Please choose an activity to remove"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:63
-msgid "Booking informations"
+msgid "Booking information"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:70 ../tempcache/bookings.html.twig:138
@@ -401,7 +401,7 @@ msgid "No activity for selected event"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:280
-msgid "Financial informations"
+msgid "Financial information"
 msgstr ""
 
 #: ../tempcache/booking.html.twig:287 ../tempcache/bookings.html.twig:138
@@ -523,7 +523,7 @@ msgid "Inactive"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:203
-msgid "%1$s: edit informations"
+msgid "%1$s: edit information"
 msgstr ""
 
 #: ../tempcache/activities.html.twig:205
@@ -569,11 +569,6 @@ msgstr ""
 #: ../tempcache/events.html.twig:243
 #, php-format
 msgid "%1$s: show bookings"
-msgstr ""
-
-#: ../tempcache/events.html.twig:253
-#, php-format
-msgid "%1$s: edit informations"
 msgstr ""
 
 #: ../tempcache/events.html.twig:266

--- a/lang/events_uk.utf8.po
+++ b/lang/events_uk.utf8.po
@@ -23,8 +23,8 @@ msgid "Event is mandatory"
 msgstr "Подія є обов'язковою"
 
 #: ../lib/GaletteEvents/Booking.php:221
-msgid "%activity is mandatory for this event!"
-msgstr "%activity є обов'язковою для цієї події!"
+msgid "%1$s is mandatory for this event!"
+msgstr "%1$s є обов'язковою для цієї події!"
 
 #: ../lib/GaletteEvents/Booking.php:255
 msgid "Please specify amount if booking has been paid ;)"
@@ -47,8 +47,8 @@ msgid "booking date"
 msgstr "дата бронювання"
 
 #: ../lib/GaletteEvents/Booking.php:357
-msgid "A booking already exists for %member in %event"
-msgstr "Для %member у події %event вже існує бронювання"
+msgid "A booking already exists for %1$s in %2$s"
+msgstr "Для %1$s у події %2$s вже існує бронювання"
 
 #: ../lib/GaletteEvents/Booking.php:424
 msgid "Booking added"
@@ -376,9 +376,9 @@ msgstr "Потрібно"
 
 #: ../tempcache/event.html.twig:330
 #, fuzzy
-#| msgid "%activity: remove from database"
+#| msgid "%1$s: remove from database"
 msgid "No activity available in the database."
-msgstr "%activity: вилучення з бази даних"
+msgstr "%1$s: вилучення з бази даних"
 
 #: ../tempcache/event.html.twig:371
 msgid "Please choose an activity to add"
@@ -445,11 +445,11 @@ msgstr "Експортувати вибрані бронювання як CSV"
 
 #: ../tempcache/bookings.html.twig:90
 #, php-format
-msgid "%count booking"
-msgid_plural "%count bookings"
-msgstr[0] "%count бронювання"
-msgstr[1] "%count бронювання"
-msgstr[2] "%count бронювань"
+msgid "%1$s booking"
+msgid_plural "%1$s bookings"
+msgstr[0] "%1$s бронювання"
+msgstr[1] "%1$s бронювання"
+msgstr[2] "%1$s бронювань"
 
 #: ../tempcache/bookings.html.twig:118 ../tempcache/calendar.html.twig:119
 msgid "New booking"
@@ -504,11 +504,11 @@ msgstr "Бронювання не знайдено"
 
 #: ../tempcache/activities.html.twig:61
 #, php-format
-msgid "%count activity"
-msgid_plural "%count activities"
-msgstr[0] "%count діяльність"
-msgstr[1] "%count діяльности"
-msgstr[2] "%count діяльностей"
+msgid "%1$s activity"
+msgid_plural "%1$s activities"
+msgstr[0] "%1$s діяльність"
+msgstr[1] "%1$s діяльности"
+msgstr[2] "%1$s діяльностей"
 
 #: ../tempcache/activities.html.twig:88
 msgid "New activity"
@@ -532,12 +532,12 @@ msgid "Inactive"
 msgstr "Незадіяний"
 
 #: ../tempcache/activities.html.twig:203
-msgid "%activity: edit informations"
-msgstr "%activity: редагування відомостей"
+msgid "%1$s: edit informations"
+msgstr "%1$s: редагування відомостей"
 
 #: ../tempcache/activities.html.twig:205
-msgid "%activity: remove from database"
-msgstr "%activity: вилучення з бази даних"
+msgid "%1$s: remove from database"
+msgstr "%1$s: вилучення з бази даних"
 
 #: ../tempcache/activities.html.twig:241
 msgid "No activity has been found"
@@ -545,11 +545,11 @@ msgstr "Жодної діяльності не знайдено"
 
 #: ../tempcache/events.html.twig:61
 #, php-format
-msgid "%count event"
-msgid_plural "%count events"
-msgstr[0] "%count подія"
-msgstr[1] "%count події"
-msgstr[2] "%count подій"
+msgid "%1$s event"
+msgid_plural "%1$s events"
+msgstr[0] "%1$s подія"
+msgstr[1] "%1$s події"
+msgstr[2] "%1$s подій"
 
 #: ../tempcache/events.html.twig:88
 msgid "New event"
@@ -573,23 +573,23 @@ msgstr "Подія закрита"
 
 #: ../tempcache/events.html.twig:233
 #, php-format
-msgid "%eventname: export bookings as CSV"
-msgstr "%eventname: експорт бронювань у форматі CSV"
+msgid "%1$s: export bookings as CSV"
+msgstr "%1$s: експорт бронювань у форматі CSV"
 
 #: ../tempcache/events.html.twig:243
 #, php-format
-msgid "%eventname: show bookings"
-msgstr "%eventname: показ бронювань"
+msgid "%1$s: show bookings"
+msgstr "%1$s: показ бронювань"
 
 #: ../tempcache/events.html.twig:253
 #, php-format
-msgid "%eventname: edit informations"
-msgstr "%eventname: редагування відомостей"
+msgid "%1$s: edit informations"
+msgstr "%1$s: редагування відомостей"
 
 #: ../tempcache/events.html.twig:266
 #, php-format
-msgid "%eventname: remove from database"
-msgstr "%eventname: вилучення з бази даних"
+msgid "%1$s: remove from database"
+msgstr "%1$s: вилучення з бази даних"
 
 #: ../tempcache/events.html.twig:311
 msgid "No event has been found"
@@ -678,8 +678,8 @@ msgstr "Сьогодні"
 #~ "ID діяльності не може дорівнювати нулю під час виклику маршруту "
 #~ "редагування!"
 
-#~ msgid "Activity %name is referenced in %count events, it cannot be removed."
-#~ msgstr "Діяльність %name посилається на %count подій, її не можна вилучити."
+#~ msgid "Activity %name is referenced in %1$s events, it cannot be removed."
+#~ msgstr "Діяльність %name посилається на %1$s подій, її не можна вилучити."
 
 #~ msgid "An error occured trying to remove activity %name :/"
 #~ msgstr "Сталася помилка під час спроби вилучити діяльність %name :/"

--- a/lang/events_uk.utf8.po
+++ b/lang/events_uk.utf8.po
@@ -312,7 +312,7 @@ msgid "Activity updated"
 msgstr "Діяльність оновлено"
 
 #: ../tempcache/event.html.twig:63 ../tempcache/activity.html.twig:63
-msgid "General informations"
+msgid "General information"
 msgstr "Загальні відомості"
 
 #: ../tempcache/event.html.twig:70
@@ -389,7 +389,7 @@ msgid "Please choose an activity to remove"
 msgstr "Виберіть діяльність, яку потрібно вилучити"
 
 #: ../tempcache/booking.html.twig:63
-msgid "Booking informations"
+msgid "Booking information"
 msgstr "Відомості про бронювання"
 
 #: ../tempcache/booking.html.twig:70 ../tempcache/bookings.html.twig:138
@@ -406,7 +406,7 @@ msgid "No activity for selected event"
 msgstr "Немає діяльностей для вибраної події"
 
 #: ../tempcache/booking.html.twig:280
-msgid "Financial informations"
+msgid "Financial information"
 msgstr "Фінансові відомості"
 
 #: ../tempcache/booking.html.twig:287 ../tempcache/bookings.html.twig:138
@@ -532,7 +532,7 @@ msgid "Inactive"
 msgstr "Незадіяний"
 
 #: ../tempcache/activities.html.twig:203
-msgid "%1$s: edit informations"
+msgid "%1$s: edit information"
 msgstr "%1$s: редагування відомостей"
 
 #: ../tempcache/activities.html.twig:205
@@ -580,11 +580,6 @@ msgstr "%1$s: експорт бронювань у форматі CSV"
 #, php-format
 msgid "%1$s: show bookings"
 msgstr "%1$s: показ бронювань"
-
-#: ../tempcache/events.html.twig:253
-#, php-format
-msgid "%1$s: edit informations"
-msgstr "%1$s: редагування відомостей"
 
 #: ../tempcache/events.html.twig:266
 #, php-format

--- a/lang/events_uk.utf8.po
+++ b/lang/events_uk.utf8.po
@@ -117,7 +117,7 @@ msgid "Activity has been modified."
 msgstr "Діяльність змінено."
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:263
-msgid "An error occured while storing the activity."
+msgid "An error occurred while storing the activity."
 msgstr "Під час зберігання діяльності сталася помилка."
 
 #: ../lib/GaletteEvents/Controllers/Crud/ActivitiesController.php:355
@@ -166,7 +166,7 @@ msgid "Event has been modified."
 msgstr "Подія було змінено."
 
 #: ../lib/GaletteEvents/Controllers/Crud/EventsController.php:414
-msgid "An error occured while storing the event."
+msgid "An error occurred while storing the event."
 msgstr "Під час зберігання події сталася помилка."
 
 #. TRANS: first parameter is the event name
@@ -656,7 +656,7 @@ msgstr "Сьогодні"
 #~ msgstr ""
 #~ "ID події не може призвести до нульового виклику редагування маршруту!"
 
-#~ msgid "An error occured trying to remove event %name :/"
+#~ msgid "An error occurred trying to remove event %name :/"
 #~ msgstr "Сталася помилка під час спроби вилучити подію %name :/"
 
 #~ msgid "Event %name has been successfully deleted."
@@ -667,7 +667,7 @@ msgstr "Сьогодні"
 #~ "ID бронювання не може дорівнювати нулю під час виклику маршруту "
 #~ "редагування!"
 
-#~ msgid "An error occured trying to remove booking :/"
+#~ msgid "An error occurred trying to remove booking :/"
 #~ msgstr "Сталася помилка при спробі вилучити бронювання :/"
 
 #~ msgid "Booking has been successfully deleted."
@@ -681,7 +681,7 @@ msgstr "Сьогодні"
 #~ msgid "Activity %name is referenced in %1$s events, it cannot be removed."
 #~ msgstr "Діяльність %name посилається на %1$s подій, її не можна вилучити."
 
-#~ msgid "An error occured trying to remove activity %name :/"
+#~ msgid "An error occurred trying to remove activity %name :/"
 #~ msgstr "Сталася помилка під час спроби вилучити діяльність %name :/"
 
 #~ msgid "Activity %name has been successfully deleted."

--- a/lib/GaletteEvents/Activity.php
+++ b/lib/GaletteEvents/Activity.php
@@ -120,7 +120,6 @@ class Activity
                 Analog::WARNING
             );
             throw $e;
-            return false;
         }
     }
 
@@ -296,7 +295,6 @@ class Activity
                 Analog::ERROR
             );
             throw $e;
-            return false;
         }
     }
 

--- a/lib/GaletteEvents/Activity.php
+++ b/lib/GaletteEvents/Activity.php
@@ -266,7 +266,7 @@ class Activity
                 } else {
                     $hist->add(_T("Fail to add new activity.", "events"));
                     throw new \Exception(
-                        'An error occured inserting new activity!'
+                        'An error occurred inserting new activity!'
                     );
                 }
             } else {

--- a/lib/GaletteEvents/Booking.php
+++ b/lib/GaletteEvents/Booking.php
@@ -416,7 +416,7 @@ class Booking
                 } else {
                     $hist->add(_T("Fail to add new booking.", "events"));
                     throw new \Exception(
-                        'An error occured inserting new booking!'
+                        'An error occurred inserting new booking!'
                     );
                 }
             } else {

--- a/lib/GaletteEvents/Booking.php
+++ b/lib/GaletteEvents/Booking.php
@@ -127,7 +127,6 @@ class Booking
                 Analog::WARNING
             );
             throw $e;
-            return false;
         }
     }
 
@@ -559,7 +558,6 @@ class Booking
                 Analog::ERROR
             );
             throw $e;
-            return false;
         }
     }
 

--- a/lib/GaletteEvents/Booking.php
+++ b/lib/GaletteEvents/Booking.php
@@ -215,10 +215,10 @@ class Booking
                     $event->isActivityRequired($aid)
                     && (!isset($values['activities']) || !in_array($aid, $values['activities']))
                 ) {
-                    $this->errors[] = str_replace(
-                        '%activity',
-                        $entry['activity']->getName(),
-                        _T('%activity is mandatory for this event!', 'events')
+                    $this->errors[] = sprintf(
+                        //TRANS: %1$s is activity name
+                        _T('%1$s is mandatory for this event!', 'events'),
+                        $entry['activity']->getName()
                     );
                 } else {
                     $act = [
@@ -316,16 +316,11 @@ class Booking
                     __("Y-m-d") . ' | ' . $e->getMessage(),
                     Analog::INFO
                 );
-                $this->errors[] = str_replace(
-                    array(
-                        '%date_format',
-                        '%field'
-                    ),
-                    array(
-                        __("Y-m-d"),
-                        __('booking date', 'events')
-                    ),
-                    _T("- Wrong date format (%date_format) for %field!")
+                $this->errors[] = sprintf(
+                    //TRANS %1$s is the expected date format, %2$s is the field label
+                    _T('- Wrong date format (%1$s) for %2$s!'),
+                    __("Y-m-d"),
+                    __('booking date', 'events')
                 );
             }
         }
@@ -345,16 +340,11 @@ class Booking
             }
             $results = $this->zdb->execute($select);
             if ($results->count()) {
-                $this->errors[] = str_replace(
-                    [
-                        '%member',
-                        '%event'
-                    ],
-                    [
-                        $this->getMember()->sfullname,
-                        $this->getEvent()->getName()
-                    ],
-                    _T('A booking already exists for %member in %event', 'events')
+                $this->errors[] = sprintf(
+                    //TRANS: first replacement is member name, second is event name
+                    _T('A booking already exists for %1$s in %2$s', 'events'),
+                    $this->getMember()->sfullname,
+                    $this->getEvent()->getName()
                 );
             }
         }
@@ -506,7 +496,7 @@ class Booking
                     ++$count;
                 }
                 Analog::log(
-                    str_replace('%count', $count, '%count activities removed'),
+                    sprintf('%1$s activities removed', $count),
                     Analog::INFO
                 );
             }
@@ -530,7 +520,7 @@ class Booking
                     ++$count;
                 }
                 Analog::log(
-                    str_replace('%count', $count, '%count activities updated'),
+                    sprintf('%1$s activities updated', $count),
                     Analog::INFO
                 );
             }
@@ -554,7 +544,7 @@ class Booking
                     ++$count;
                 }
                 Analog::log(
-                    str_replace('%count', $count, '%count activities added'),
+                    sprintf('%1$s activities added', $count),
                     Analog::INFO
                 );
             }

--- a/lib/GaletteEvents/Controllers/Crud/ActivitiesController.php
+++ b/lib/GaletteEvents/Controllers/Crud/ActivitiesController.php
@@ -352,6 +352,7 @@ class ActivitiesController extends AbstractPluginController
     {
         $activity = new Activity($this->zdb, $this->login, (int)$args['id']);
         return sprintf(
+            //TRANS %1$s is activity name
             _T('Remove activity %1$s', 'events'),
             $activity->getName()
         );

--- a/lib/GaletteEvents/Controllers/Crud/ActivitiesController.php
+++ b/lib/GaletteEvents/Controllers/Crud/ActivitiesController.php
@@ -273,14 +273,6 @@ class ActivitiesController extends AbstractPluginController
             }
         }
 
-        if (count($warning_detected) > 0) {
-            foreach ($warning_detected as $warning) {
-                $this->flash->addMessage(
-                    'warning_detected',
-                    $warning
-                );
-            }
-        }
         if (count($success_detected) > 0) {
             foreach ($success_detected as $success) {
                 $this->flash->addMessage(

--- a/lib/GaletteEvents/Controllers/Crud/ActivitiesController.php
+++ b/lib/GaletteEvents/Controllers/Crud/ActivitiesController.php
@@ -260,7 +260,7 @@ class ActivitiesController extends AbstractPluginController
                 }
             } else {
                 //something went wrong :'(
-                $error_detected[] = _T("An error occured while storing the activity.", "events");
+                $error_detected[] = _T("An error occurred while storing the activity.", "events");
             }
         }
 

--- a/lib/GaletteEvents/Controllers/Crud/BookingsController.php
+++ b/lib/GaletteEvents/Controllers/Crud/BookingsController.php
@@ -644,7 +644,7 @@ class BookingsController extends AbstractPluginController
         $member = $booking->getMember();
         $event = $booking->getEvent();
         return sprintf(
-            //TRANS: first parameter is the member name, second the event name.
+            //TRANS: %1$s is the member name, %2$s the event name.
             _T('Remove booking for %1$s on %2$s', 'events'),
             $member->sname,
             $event->getName()

--- a/lib/GaletteEvents/Controllers/Crud/EventsController.php
+++ b/lib/GaletteEvents/Controllers/Crud/EventsController.php
@@ -411,7 +411,7 @@ class EventsController extends AbstractPluginController
                     }
                 } else {
                     //something went wrong :'(
-                    $error_detected[] = _T("An error occured while storing the event.", "events");
+                    $error_detected[] = _T("An error occurred while storing the event.", "events");
                 }
             }
         }

--- a/lib/GaletteEvents/Controllers/Crud/EventsController.php
+++ b/lib/GaletteEvents/Controllers/Crud/EventsController.php
@@ -510,7 +510,7 @@ class EventsController extends AbstractPluginController
     {
         $event = new Event($this->zdb, $this->login, (int)$args['id']);
         return sprintf(
-            //TRANS: first parameter is the event name
+            //TRANS: %1$s is the event name
             _T('Remove event \'%1$s\'"', 'events'),
             $event->getName()
         );

--- a/lib/GaletteEvents/Event.php
+++ b/lib/GaletteEvents/Event.php
@@ -424,7 +424,7 @@ class Event
                 } else {
                     $hist->add(_T("Fail to add new event.", "events"));
                     throw new \Exception(
-                        'An error occured inserting new event!'
+                        'An error occurred inserting new event!'
                     );
                 }
             } else {

--- a/lib/GaletteEvents/Event.php
+++ b/lib/GaletteEvents/Event.php
@@ -242,16 +242,11 @@ class Event
                         } else {
                             $label = _T('End date', 'events');
                         }
-                        $this->errors[] = str_replace(
-                            array(
-                                '%date_format',
-                                '%field'
-                            ),
-                            array(
-                                __("Y-m-d"),
-                                $label
-                            ),
-                            _T("- Wrong date format (%date_format) for %field!")
+                        $this->errors[] = sprintf(
+                            //TRANS %1$s is the expected date format, %2$s is the field label
+                            _T('- Wrong date format (%1$s) for %2$s!'),
+                            __("Y-m-d"),
+                            $label
                         );
                     }
                 }
@@ -502,7 +497,7 @@ class Event
                     ++$count;
                 }
                 Analog::log(
-                    str_replace('%count', $count, '%count activities removed'),
+                    sprintf('%1$s activities removed', $count),
                     Analog::INFO
                 );
             }
@@ -518,7 +513,7 @@ class Event
                     ++$count;
                 }
                 Analog::log(
-                    str_replace('%count', $count, '%count activities updated'),
+                    sprintf('%1$s activities updated', $count),
                     Analog::INFO
                 );
             }
@@ -532,7 +527,7 @@ class Event
                     ++$count;
                 }
                 Analog::log(
-                    str_replace('%count', $count, '%count activities added'),
+                    sprintf('%1$s activities added', $count),
                     Analog::INFO
                 );
             }

--- a/lib/GaletteEvents/Filters/ActivitiesList.php
+++ b/lib/GaletteEvents/Filters/ActivitiesList.php
@@ -138,7 +138,7 @@ class ActivitiesList extends Pagination
      * Global setter method
      *
      * @param string $name  name of the property we want to assign a value to
-     * @param object $value a relevant value for the property
+     * @param mixed  $value a relevant value for the property
      *
      * @return void
      */

--- a/lib/GaletteEvents/Filters/BookingsList.php
+++ b/lib/GaletteEvents/Filters/BookingsList.php
@@ -148,7 +148,7 @@ class BookingsList extends Pagination
      * Global setter method
      *
      * @param string $name  name of the property we want to assign a value to
-     * @param object $value a relevant value for the property
+     * @param mixed  $value a relevant value for the property
      *
      * @return void
      */

--- a/lib/GaletteEvents/Filters/EventsList.php
+++ b/lib/GaletteEvents/Filters/EventsList.php
@@ -254,13 +254,9 @@ class EventsList extends Pagination
                                 }
 
                                 throw new \Exception(
-                                    str_replace(
-                                        array('%field', '%format'),
-                                        array(
-                                            $field,
-                                            implode(', ', $formats)
-                                        ),
-                                        _T("Unknown date format for %field.<br/>Know formats are: %formats")
+                                    sprintf(
+                                        //TRANS: %1$s is field label, %2$s is list of known date formats
+                                        _T('Unknown date format for %1$s.<br/>Know formats are: %2$s')
                                     )
                                 );
                             }

--- a/lib/GaletteEvents/Filters/EventsList.php
+++ b/lib/GaletteEvents/Filters/EventsList.php
@@ -147,10 +147,8 @@ class EventsList extends Pagination
                 switch ($name) {
                     case 'raw_start_date_filter':
                         return $this->start_date_filter;
-                        break;
                     case 'raw_end_date_filter':
                         return $this->end_date_filter;
-                        break;
                     case 'start_date_filter':
                     case 'end_date_filter':
                         try {
@@ -184,7 +182,7 @@ class EventsList extends Pagination
      * Global setter method
      *
      * @param string $name  name of the property we want to assign a value to
-     * @param object $value a relevant value for the property
+     * @param mixed  $value a relevant value for the property
      *
      * @return void
      */

--- a/lib/GaletteEvents/Filters/EventsList.php
+++ b/lib/GaletteEvents/Filters/EventsList.php
@@ -171,7 +171,7 @@ class EventsList extends Pagination
                 }
             } else {
                 Analog::log(
-                    '[EventsList] Unable to get proprety `' . $name . '`',
+                    '[EventsList] Unable to get property `' . $name . '`',
                     Analog::WARNING
                 );
             }

--- a/lib/GaletteEvents/Repository/Bookings.php
+++ b/lib/GaletteEvents/Repository/Bookings.php
@@ -137,18 +137,19 @@ class Bookings
     /**
      * Builds the SELECT statement
      *
-     * @param array $fields fields list to retrieve
-     * @param bool  $count  true if we want to count members
-     *                      (not applicable from static calls), defaults to false
+     * @param ?array $fields fields list to retrieve
+     * @param bool   $count  true if we want to count members
+     *                       (not applicable from static calls), defaults to false
      *
      * @return Select SELECT statement
      */
     private function buildSelect($fields, $count = false)
     {
         try {
-            $fieldsList = ( $fields != null )
-                            ? (( !is_array($fields) || count($fields) < 1 ) ? (array)'*'
-                            : implode(', ', $fields)) : (array)'*';
+            $fieldsList = ['*'];
+            if (is_array($fields) && count($fields)) {
+                $fieldsList = $fields;
+            }
 
             $select = $this->zdb->select(EVENTS_PREFIX . Booking::TABLE, 'b');
             $select->columns($fieldsList);

--- a/lib/GaletteEvents/Repository/Events.php
+++ b/lib/GaletteEvents/Repository/Events.php
@@ -233,6 +233,7 @@ class Events
 
                     $attendees_str = $total_attendees;
                     if ($total_attendees) {
+                        //TRANS: %1$s is the number of paid attendees
                         $attendees_str .= ' (' . sprintf(_T('%1$s paid', 'events'), $paid_attendees) . ')';
                     }
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,7 @@
 parameters:
     parallel:
         maximumNumberOfProcesses: 2
-    level: 3
+    level: 4
     paths:
         - lib/
     scanFiles:

--- a/templates/default/activities.html.twig
+++ b/templates/default/activities.html.twig
@@ -62,7 +62,7 @@
             <td class="center nowrap actions_row">
                 {% set actions = [
                     {
-                        'label': _T("%1$s: edit informations", "events")|replace({"%1$s": activity.getName()}),
+                        'label': _T("%1$s: edit information", "events")|replace({"%1$s": activity.getName()}),
                         'route': {
                         'name': 'events_activity_edit',
                             'args': {'id': aid}

--- a/templates/default/activities.html.twig
+++ b/templates/default/activities.html.twig
@@ -11,7 +11,7 @@
 
 {% block infoline %}
     {% set infoline = {
-        'label': _Tn("%count activity", "%count activities", nb, "events")|replace({"%count": nb}),
+        'label': _Tn("%1$s activity", "%1$s activities", nb, "events")|replace({"%1$s": nb}),
     } %}
     {{ parent() }}
 {% endblock %}
@@ -62,7 +62,7 @@
             <td class="center nowrap actions_row">
                 {% set actions = [
                     {
-                        'label': _T("%activity: edit informations", "events")|replace({"%activity": activity.getName()}),
+                        'label': _T("%1$s: edit informations", "events")|replace({"%1$s": activity.getName()}),
                         'route': {
                         'name': 'events_activity_edit',
                             'args': {'id': aid}
@@ -70,7 +70,7 @@
                         'icon': 'edit'
                     },
                     {
-                        'label': _T("%activity: remove from database", "events")|replace({"%activity": activity.getName()}),
+                        'label': _T("%1$s: remove from database", "events")|replace({"%1$s": activity.getName()}),
                         'route': {
                         'name': 'events_remove_activity',
                             'args': {'id': aid}

--- a/templates/default/activity.html.twig
+++ b/templates/default/activity.html.twig
@@ -5,7 +5,7 @@
         <div class="ui styled fluid accordion field">
             <div class="active title">
                 <i class="icon dropdown"></i>
-                {{ _T("General informations", "events") }}
+                {{ _T("General information", "events") }}
             </div>
             <div class="active content">
                 {% include "components/forms/checkbox.html.twig" with {

--- a/templates/default/booking.html.twig
+++ b/templates/default/booking.html.twig
@@ -5,7 +5,7 @@
         <div class="ui styled fluid accordion field">
             <div class="active title">
                 <i class="icon dropdown"></i>
-                {{ _T("Booking informations", "events") }}
+                {{ _T("Booking information", "events") }}
             </div>
             <div class="active content">
                 {% include "components/forms/date.html.twig" with {
@@ -100,7 +100,7 @@
         <div class="ui styled fluid accordion field">
             <div class="active title">
                 <i class="icon dropdown"></i>
-                {{ _T("Financial informations", "events") }}
+                {{ _T("Financial information", "events") }}
             </div>
             <div class="active content">
                 {% include "components/forms/checkbox.html.twig" with {

--- a/templates/default/bookings.html.twig
+++ b/templates/default/bookings.html.twig
@@ -17,7 +17,7 @@
 
 {% block infoline %}
     {% set infoline = {
-        'label': _Tn("%count booking", "%count bookings", nb, "events")|replace({"%count": nb}),
+        'label': _Tn("%1$s booking", "%1$s bookings", nb, "events")|replace({"%1$s": nb}),
     } %}
     {{ parent() }}
 {% endblock %}

--- a/templates/default/event.html.twig
+++ b/templates/default/event.html.twig
@@ -5,7 +5,7 @@
         <div class="ui styled fluid accordion field">
             <div class="active title">
                 <i class="icon dropdown"></i>
-                {{ _T("General informations", "events") }}
+                {{ _T("General information", "events") }}
             </div>
             <div class="active content">
                 {% include "components/forms/checkbox.html.twig" with {

--- a/templates/default/events.html.twig
+++ b/templates/default/events.html.twig
@@ -11,7 +11,7 @@
 
 {% block infoline %}
     {% set infoline = {
-        'label': _Tn("%count event", "%count events", nb, "events")|replace({"%count": nb}),
+        'label': _Tn("%1$s event", "%1$s events", nb, "events")|replace({"%1$s": nb}),
     } %}
     {{ parent() }}
 {% endblock %}
@@ -74,7 +74,7 @@
             {% if login.isAdmin() or login.isStaff() or (login.isGroupManager() and event.getGroup() in login.managed_groups) %}
                 {% set actions = (actions ?? [])|merge([
                     {
-                        'label': _T("%eventname: export bookings as CSV", "events")|replace({"%eventname": event.getName()}),
+                        'label': _T("%1$s: export bookings as CSV", "events")|replace({"%1$s": event.getName()}),
                         'route': {
                         'name': 'event_bookings_export',
                             'args': {'id': eid}
@@ -87,7 +87,7 @@
 
             {% set actions = (actions ?? [])|merge([
                 {
-                    'label': _T("%eventname: show bookings", "events")|replace({"%eventname": event.getName()}),
+                    'label': _T("%1$s: show bookings", "events")|replace({"%1$s": event.getName()}),
                     'route': {
                     'name': 'events_bookings',
                         'args': {'event': eid}
@@ -99,7 +99,7 @@
             {% if login.isAdmin() or login.isStaff() or (login.isGroupManager() and event.getGroup() in login.managed_groups) %}
                 {% set actions = actions|merge([
                     {
-                        'label': _T("%eventname: edit informations", "events")|replace({"%eventname": event.getName()}),
+                        'label': _T("%1$s: edit informations", "events")|replace({"%1$s": event.getName()}),
                         'route': {
                         'name': 'events_event_edit',
                             'args': {'id': eid}
@@ -112,7 +112,7 @@
             {% if login.isAdmin() or login.isStaff() %}
                 {% set actions = actions|merge([
                     {
-                        'label': _T("%eventname: remove from database", "events")|replace({"%eventname": event.getName()}),
+                        'label': _T("%1$s: remove from database", "events")|replace({"%1$s": event.getName()}),
                         'route': {
                         'name': 'events_remove_event',
                         'args': {'id': eid}

--- a/templates/default/events.html.twig
+++ b/templates/default/events.html.twig
@@ -99,7 +99,7 @@
             {% if login.isAdmin() or login.isStaff() or (login.isGroupManager() and event.getGroup() in login.managed_groups) %}
                 {% set actions = actions|merge([
                     {
-                        'label': _T("%1$s: edit informations", "events")|replace({"%1$s": event.getName()}),
+                        'label': _T("%1$s: edit information", "events")|replace({"%1$s": event.getName()}),
                         'route': {
                         'name': 'events_event_edit',
                             'args': {'id': eid}


### PR DESCRIPTION
Some translators misunderstand replacements and translate them, leading to errors.

Initial goal was to have self explanatory replacements, bit now I've replaced them with standard `sprintf()` parameters along with a translation comment.