### PR TITLE
Restore records per page select on lists; fixes #1757 and #1758

### DIFF
--- a/_define.php
+++ b/_define.php
@@ -61,6 +61,7 @@ $this->register(
         'filter-bookingslist'       => 'member',
         'batch-eventslist'          => 'groupmanager',
         'events_activities'         => 'staff',
+        'filter-activitieslist'     => 'staff',
         'events_activity_add'       => 'staff',
         'events_activity_edit'      => 'staff',
         'events_storeactivity_add'  => 'staff',

--- a/_routes.php
+++ b/_routes.php
@@ -161,6 +161,11 @@ $app->get(
     [ActivitiesController::class, 'list']
 )->setName('events_activities')->add($authenticate);
 
+$app->post(
+    '/activities/filter',
+    [ActivitiesController::class, 'filter']
+)->setName('filter-activitieslist')->add($authenticate);
+
 $app->get(
     '/activity/add',
     [ActivitiesController::class, 'add']

--- a/lib/GaletteEvents/Controllers/Crud/ActivitiesController.php
+++ b/lib/GaletteEvents/Controllers/Crud/ActivitiesController.php
@@ -162,8 +162,28 @@ class ActivitiesController extends AbstractPluginController
      */
     public function filter(Request $request, Response $response): Response
     {
-        //no filter
-        return $response;
+        $post = $request->getParsedBody();
+        if (isset($this->session->filter_activities)) {
+            $filters = $this->session->filter_activities;
+        } else {
+            $filters = new ActivitiesList();
+        }
+
+        //reinitialize filters
+        if (isset($post['clear_filter'])) {
+            $filters->reinit();
+        } else {
+            //number of rows to show
+            if (isset($post['nbshow'])) {
+                $filters->show = $post['nbshow'];
+            }
+        }
+
+        $this->session->filter_activities = $filters;
+
+        return $response
+            ->withStatus(301)
+            ->withHeader('Location', $this->routeparser->urlFor('events_activities'));
     }
 
     // /CRUD - Read

--- a/templates/default/activities.html.twig
+++ b/templates/default/activities.html.twig
@@ -12,6 +12,9 @@
 {% block infoline %}
     {% set infoline = {
         'label': _Tn("%1$s activity", "%1$s activities", nb, "events")|replace({"%1$s": nb}),
+        'route': {
+            'name': 'filter-activitieslist'
+        }
     } %}
     {{ parent() }}
 {% endblock %}

--- a/templates/default/bookings.html.twig
+++ b/templates/default/bookings.html.twig
@@ -18,6 +18,12 @@
 {% block infoline %}
     {% set infoline = {
         'label': _Tn("%1$s booking", "%1$s bookings", nb, "events")|replace({"%1$s": nb}),
+        'route': {
+            'name': 'filter-bookingslist',
+            'args': {
+                "event": "all"
+            }
+        }
     } %}
     {{ parent() }}
 {% endblock %}

--- a/templates/default/events.html.twig
+++ b/templates/default/events.html.twig
@@ -12,6 +12,9 @@
 {% block infoline %}
     {% set infoline = {
         'label': _Tn("%1$s event", "%1$s events", nb, "events")|replace({"%1$s": nb}),
+        'route': {
+            'name': 'filter-eventslist'
+        }
     } %}
     {{ parent() }}
 {% endblock %}


### PR DESCRIPTION
However, there is still an issue with pagination on bookings and events lists (pagination on activities seems to be OK).

I don't know how to fix that :

- on events, pagination is never displayed because the count of events is always `1` (have a look at the screenshot on the tracker : https://bugs.galette.eu/attachments/539)

- on bookings, pagination is correctly displayed only if filters are not used at first. For example, when changing the number of records per page with the select, the pagination shows the wrong number of pages and remains even in case of a single page of results ; the pagination is "updated" only after refreshing the page (even when using the "Clear filters" button).